### PR TITLE
feat: flat output layout (clean break, no src/ wrapper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ All notable changes to this project will be documented in this file.
 - **Old `src/` paths break on republish** - This is a clean break: no compatibility layer ships. Literal deep URLs into previously published packages (`cdn.jsdelivr.net/npm/<pkg>/src/index.js`) 404 once the package republishes with 0.2.0. Node consumers are unaffected: exports-map keys never contained `src/`, and bare specifiers resolve through the regenerated map.
 - **`--save` paths** - Root package.json now points at `./dist/<entry>.*` (was `./dist/src/<entry>.*`). Old saved paths are migrated automatically on the next `--save` run.
 
+### Added
+- **`.tsx` entry points** - Top-level `.tsx` files in `src/` are now discovered as entry points. esbuild and the declaration generator honor the project's tsconfig `jsx`/`jsxImportSource` settings (or `/** @jsx */` pragmas); declarations fall back to `jsx: preserve`. Fixes [#6](https://github.com/bikeshaving/libuild/issues/6).
+
 ### Fixed
 - **UMD build corrupted sibling entries** - The UMD wrapper was applied to every `.js` file in the output directory, silently wrapping (and breaking) other entry modules in packages with a `src/umd.ts`. It now wraps only the UMD output file.
 - **`--save` bin pointed at stale nested paths** - Saved bin paths are normalized to the flat artifact locations.
+- **`--save` dropped the `import` condition from the `.` export** - A types-only `"."` export passed through without its `import` (and `require`) conditions, breaking bundler resolution of symlinked packages. Missing conditions are now filled in from the main entry. Fixes [#7](https://github.com/bikeshaving/libuild/issues/7).
+- **npm flag filtering restored on `libuild publish`** - The flag whitelist from the original security hardening was silently dropped in the commander CLI rewrite; unknown or unsafe npm flags are again warned about and stripped instead of being forwarded (or hard-crashing the publish).
+
+### Maintenance
+- **esbuild `^0.19` → `^0.28`**, commander 15, dependency patch bumps.
+- Removed dead code paths (unreachable `src/bin` entry flavor, unused parameters).
 
 ## [0.1.25] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.0] - 2026-07-17
 
-### Changed
+### Changed (BREAKING)
 - **Flat output layout** - Modules now publish at the package root (`<pkg>/index.js`) instead of nested under `src/` (`<pkg>/src/index.js`). Direct CDN file URLs (jsDelivr, unpkg) serve literal paths and do not consult the exports map, so the old layout 404'd copy-paste URLs like `cdn.jsdelivr.net/npm/<pkg>/index.js`. Executables stay under `bin/`, code-splitting chunks move to `_chunks/` (was `src/_chunks/`). Fixes [#9](https://github.com/bikeshaving/libuild/issues/9).
-- **Compatibility stubs** - `dist/src/` now contains tiny re-export shims (plus a full UMD copy) so `<pkg>/src/<entry>.js` paths from packages published with older libuild versions keep resolving - old CDN URLs and literal deep imports do not break. Node consumers are unaffected either way: exports-map keys never contained `src/`.
+- **Old `src/` paths break on republish** - This is a clean break: no compatibility layer ships. Literal deep URLs into previously published packages (`cdn.jsdelivr.net/npm/<pkg>/src/index.js`) 404 once the package republishes with 0.2.0. Node consumers are unaffected: exports-map keys never contained `src/`, and bare specifiers resolve through the regenerated map.
 - **`--save` paths** - Root package.json now points at `./dist/<entry>.*` (was `./dist/src/<entry>.*`). Old saved paths are migrated automatically on the next `--save` run.
 
 ### Fixed
 - **UMD build corrupted sibling entries** - The UMD wrapper was applied to every `.js` file in the output directory, silently wrapping (and breaking) other entry modules in packages with a `src/umd.ts`. It now wraps only the UMD output file.
-- **`--save` bin pointed at non-executables** - Bin paths that resolve to a file that exists but is not the built executable are now normalized to the real artifact.
-
-### Notes
-- Deep links to *internal* files of previously published packages (e.g. `<pkg>/src/plugins/x.d.ts`) are not stubbed - only entry points are. Internal paths were never part of the public contract.
+- **`--save` bin pointed at stale nested paths** - Saved bin paths are normalized to the flat artifact locations.
 
 ## [0.1.25] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-07-17
+
+### Changed
+- **Flat output layout** - Modules now publish at the package root (`<pkg>/index.js`) instead of nested under `src/` (`<pkg>/src/index.js`). Direct CDN file URLs (jsDelivr, unpkg) serve literal paths and do not consult the exports map, so the old layout 404'd copy-paste URLs like `cdn.jsdelivr.net/npm/<pkg>/index.js`. Executables stay under `bin/`, code-splitting chunks move to `_chunks/` (was `src/_chunks/`). Fixes [#9](https://github.com/bikeshaving/libuild/issues/9).
+- **Compatibility stubs** - `dist/src/` now contains tiny re-export shims (plus a full UMD copy) so `<pkg>/src/<entry>.js` paths from packages published with older libuild versions keep resolving - old CDN URLs and literal deep imports do not break. Node consumers are unaffected either way: exports-map keys never contained `src/`.
+- **`--save` paths** - Root package.json now points at `./dist/<entry>.*` (was `./dist/src/<entry>.*`). Old saved paths are migrated automatically on the next `--save` run.
+
+### Fixed
+- **UMD build corrupted sibling entries** - The UMD wrapper was applied to every `.js` file in the output directory, silently wrapping (and breaking) other entry modules in packages with a `src/umd.ts`. It now wraps only the UMD output file.
+- **`--save` bin pointed at non-executables** - Bin paths that resolve to a file that exists but is not the built executable are now normalized to the real artifact.
+
+### Notes
+- Deep links to *internal* files of previously published packages (e.g. `<pkg>/src/plugins/x.d.ts`) are not stubbed - only entry points are. Internal paths were never part of the public contract.
+
 ## [0.1.25] - 2026-07-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ libuild publish
 ### Output Structure
 - **Flat output**: `src/index.ts` → `dist/index.js` - modules publish at the package root, so direct CDN URLs like `cdn.jsdelivr.net/npm/<pkg>/index.js` just work
 - **Executables**: `bin/cli.ts` → `dist/bin/cli.js` (bin/ stays a subdirectory)
-- **Compatibility stubs**: `dist/src/` contains tiny re-export shims so `<pkg>/src/index.js` paths from packages published with older libuild versions keep resolving
 - **ESM**: `.js` files with ES module syntax
 - **CommonJS**: `.cjs` files for Node.js compatibility
 - **TypeScript**: `.d.ts` declaration files for all modules (when TypeScript is available); internal modules relocate together with their imports intact
@@ -89,9 +88,6 @@ dist/
   utils.js
   utils.cjs
   utils.d.ts
-  src/             # Compatibility stubs (re-export shims for old src/ paths)
-    index.js
-    ...
   package.json     # Clean consumer version
 ```
 
@@ -117,7 +113,6 @@ dist/
   cli.js           # Compiled CLI (dual-runtime shebang, executable)
   cli.cjs
   cli.d.ts
-  src/             # Compatibility stubs
   package.json     # bin: { "mytool": "cli.js" }
 ```
 
@@ -142,7 +137,6 @@ dist/
   index.d.ts
   utils.js         # ESM only
   utils.d.ts
-  src/             # Compatibility stubs
   package.json     # ESM-only exports
 ```
 
@@ -165,7 +159,6 @@ dist/
   utils.cjs
   utils.d.ts
   umd.js           # UMD browser build
-  src/             # Compatibility stubs (src/umd.js is a full UMD copy)
   package.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ libuild publish
 - **UMD builds**: If `src/umd.ts` exists, creates browser-compatible UMD build
 
 ### Output Structure
-- **Structure-preserving**: `src/index.ts` → `dist/src/index.js` (maintains src/ directory)
+- **Flat output**: `src/index.ts` → `dist/index.js` - modules publish at the package root, so direct CDN URLs like `cdn.jsdelivr.net/npm/<pkg>/index.js` just work
+- **Executables**: `bin/cli.ts` → `dist/bin/cli.js` (bin/ stays a subdirectory)
+- **Compatibility stubs**: `dist/src/` contains tiny re-export shims so `<pkg>/src/index.js` paths from packages published with older libuild versions keep resolving
 - **ESM**: `.js` files with ES module syntax
 - **CommonJS**: `.cjs` files for Node.js compatibility
-- **TypeScript**: `.d.ts` declaration files for all modules (when TypeScript is available)
+- **TypeScript**: `.d.ts` declaration files for all modules (when TypeScript is available); internal modules relocate together with their imports intact
 - **Module augmentation**: `declare module` blocks are preserved in .d.ts output
-- **Code splitting**: Dynamic imports create chunks in `dist/src/_chunks/`
+- **Code splitting**: Dynamic imports create chunks in `dist/_chunks/`
 - **Clean package.json**: Optimized for consumers (no dev scripts)
 
 ### Format Control
@@ -61,8 +63,8 @@ libuild publish
 
 ### Package.json Transformations
 - **Development mode** (default): Root package.json unchanged, no git noise
-- **--save mode**: Root package.json updated to point to `./dist/src/*` artifacts for npm link
-- **Dist package.json**: Clean consumer-ready version with relative `src/` paths
+- **--save mode**: Root package.json updated to point to `./dist/*` artifacts for npm link
+- **Dist package.json**: Clean consumer-ready version with root-relative paths
 - **Bin paths**: Automatically transformed from `src/` references to built artifacts
 - **Exports field**: Generated for all entry points with proper types-first ordering
 
@@ -81,13 +83,15 @@ src/
 Produces:
 ```
 dist/
-  src/
-    index.js       # ESM
-    index.cjs      # CommonJS
-    index.d.ts     # TypeScript declarations
-    utils.js
-    utils.cjs
-    utils.d.ts
+  index.js         # ESM
+  index.cjs        # CommonJS
+  index.d.ts       # TypeScript declarations
+  utils.js
+  utils.cjs
+  utils.d.ts
+  src/             # Compatibility stubs (re-export shims for old src/ paths)
+    index.js
+    ...
   package.json     # Clean consumer version
 ```
 
@@ -107,14 +111,14 @@ src/
 Produces:
 ```
 dist/
-  src/
-    index.js
-    index.cjs
-    index.d.ts
-    cli.js         # Compiled CLI
-    cli.cjs
-    cli.d.ts
-  package.json     # bin: { "mytool": "./src/cli.js" }
+  index.js
+  index.cjs
+  index.d.ts
+  cli.js           # Compiled CLI (dual-runtime shebang, executable)
+  cli.cjs
+  cli.d.ts
+  src/             # Compatibility stubs
+  package.json     # bin: { "mytool": "cli.js" }
 ```
 
 ### ESM-Only Library
@@ -125,8 +129,8 @@ To build only ESM (no CommonJS), remove the `main` field:
 // package.json
 {
   "name": "my-lib",
-  "module": "dist/src/index.js",  // ESM entry
-  "types": "dist/src/index.d.ts"
+  "module": "dist/index.js",  // ESM entry
+  "types": "dist/index.d.ts"
   // no "main" field = no CJS
 }
 ```
@@ -134,11 +138,11 @@ To build only ESM (no CommonJS), remove the `main` field:
 Produces:
 ```
 dist/
-  src/
-    index.js       # ESM only
-    index.d.ts
-    utils.js       # ESM only
-    utils.d.ts
+  index.js         # ESM only
+  index.d.ts
+  utils.js         # ESM only
+  utils.d.ts
+  src/             # Compatibility stubs
   package.json     # ESM-only exports
 ```
 
@@ -154,14 +158,14 @@ src/
 Produces:
 ```
 dist/
-  src/
-    index.js
-    index.cjs
-    index.d.ts
-    utils.js
-    utils.cjs
-    utils.d.ts
-    umd.js         # UMD browser build
+  index.js
+  index.cjs
+  index.d.ts
+  utils.js
+  utils.cjs
+  utils.d.ts
+  umd.js           # UMD browser build
+  src/             # Compatibility stubs (src/umd.js is a full UMD copy)
   package.json
 ```
 
@@ -170,24 +174,24 @@ dist/
 **Dual format** (ESM + CommonJS):
 ```json
 {
-  "main": "src/index.cjs",
-  "module": "src/index.js",
-  "types": "src/index.d.ts",
+  "main": "index.cjs",
+  "module": "index.js",
+  "types": "index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
-      "import": "./src/index.js",
-      "require": "./src/index.cjs"
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./index.cjs"
     },
     "./utils": {
-      "types": "./src/utils.d.ts",
-      "import": "./src/utils.js",
-      "require": "./src/utils.cjs"
+      "types": "./utils.d.ts",
+      "import": "./utils.js",
+      "require": "./utils.cjs"
     },
     "./utils.js": {
-      "types": "./src/utils.d.ts",
-      "import": "./src/utils.js",
-      "require": "./src/utils.cjs"
+      "types": "./utils.d.ts",
+      "import": "./utils.js",
+      "require": "./utils.cjs"
     },
     "./package.json": "./package.json"
   }
@@ -197,21 +201,21 @@ dist/
 **ESM-only** (no `main` field in source):
 ```json
 {
-  "module": "src/index.js",
-  "types": "src/index.d.ts",
+  "module": "index.js",
+  "types": "index.d.ts",
   "type": "module",
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
-      "import": "./src/index.js"
+      "types": "./index.d.ts",
+      "import": "./index.js"
     },
     "./utils": {
-      "types": "./src/utils.d.ts",
-      "import": "./src/utils.js"
+      "types": "./utils.d.ts",
+      "import": "./utils.js"
     },
     "./utils.js": {
-      "types": "./src/utils.d.ts",
-      "import": "./src/utils.js"
+      "types": "./utils.d.ts",
+      "import": "./utils.js"
     },
     "./package.json": "./package.json"
   }
@@ -221,14 +225,14 @@ dist/
 **Root package.json** (with --save):
 ```json
 {
-  "main": "./dist/src/index.cjs",
-  "module": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "require": "./dist/src/index.cjs"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "libit",
       "dependencies": {
-        "commander": "^14.0.2",
-        "esbuild": "^0.19.0",
-        "expect": "^30.2.0",
-        "glob": "^13.0.0",
+        "commander": "^15.0.0",
+        "esbuild": "^0.28.1",
+        "expect": "^30.4.1",
+        "glob": "^13.0.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -29,67 +29,69 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.19.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.19.12", "", { "os": "android", "cpu": "arm" }, "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.19.12", "", { "os": "android", "cpu": "arm64" }, "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.19.12", "", { "os": "android", "cpu": "x64" }, "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.19.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.19.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.19.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.19.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.19.12", "", { "os": "linux", "cpu": "arm" }, "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.19.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.19.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.19.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.19.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.19.12", "", { "os": "linux", "cpu": "x64" }, "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.19.12", "", { "os": "none", "cpu": "x64" }, "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.19.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.19.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.19.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.19.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
 
-    "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
 
-    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
-    "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
-    "@jest/expect-utils": ["@jest/expect-utils@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0" } }, "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA=="],
+    "@jest/diff-sequences": ["@jest/diff-sequences@30.4.0", "", {}, "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g=="],
+
+    "@jest/expect-utils": ["@jest/expect-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0" } }, "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ=="],
 
     "@jest/get-type": ["@jest/get-type@30.1.0", "", {}, "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA=="],
 
-    "@jest/pattern": ["@jest/pattern@30.0.1", "", { "dependencies": { "@types/node": "*", "jest-regex-util": "30.0.1" } }, "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA=="],
+    "@jest/pattern": ["@jest/pattern@30.4.0", "", { "dependencies": { "@types/node": "*", "jest-regex-util": "30.4.0" } }, "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg=="],
 
-    "@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+    "@jest/schemas": ["@jest/schemas@30.4.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q=="],
 
-    "@jest/types": ["@jest/types@30.2.0", "", { "dependencies": { "@jest/pattern": "30.0.1", "@jest/schemas": "30.0.5", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg=="],
+    "@jest/types": ["@jest/types@30.4.1", "", { "dependencies": { "@jest/pattern": "30.4.0", "@jest/schemas": "30.4.1", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.45", "", {}, "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg=="],
 
@@ -113,7 +115,9 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "bun-types": ["bun-types@1.3.0", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ=="],
 
@@ -125,57 +129,53 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
-    "esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
-    "expect": ["expect@30.2.0", "", { "dependencies": { "@jest/expect-utils": "30.2.0", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.2.0", "jest-message-util": "30.2.0", "jest-mock": "30.2.0", "jest-util": "30.2.0" } }, "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw=="],
+    "expect": ["expect@30.4.1", "", { "dependencies": { "@jest/expect-utils": "30.4.1", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.4.1", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA=="],
 
-    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+    "jest-diff": ["jest-diff@30.4.1", "", { "dependencies": { "@jest/diff-sequences": "30.4.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.4.1" } }, "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA=="],
 
-    "jest-diff": ["jest-diff@30.2.0", "", { "dependencies": { "@jest/diff-sequences": "30.0.1", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.2.0" } }, "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A=="],
+    "jest-matcher-utils": ["jest-matcher-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "jest-diff": "30.4.1", "pretty-format": "30.4.1" } }, "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A=="],
 
-    "jest-matcher-utils": ["jest-matcher-utils@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "jest-diff": "30.2.0", "pretty-format": "30.2.0" } }, "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg=="],
+    "jest-message-util": ["jest-message-util@30.4.1", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.4.1", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "jest-util": "30.4.1", "picomatch": "^4.0.3", "pretty-format": "30.4.1", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ=="],
 
-    "jest-message-util": ["jest-message-util@30.2.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.2.0", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "micromatch": "^4.0.8", "pretty-format": "30.2.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw=="],
+    "jest-mock": ["jest-mock@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "jest-util": "30.4.1" } }, "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw=="],
 
-    "jest-mock": ["jest-mock@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "jest-util": "30.2.0" } }, "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw=="],
+    "jest-regex-util": ["jest-regex-util@30.4.0", "", {}, "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg=="],
 
-    "jest-regex-util": ["jest-regex-util@30.0.1", "", {}, "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA=="],
-
-    "jest-util": ["jest-util@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.2" } }, "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA=="],
+    "jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
-    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+    "pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
-    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+    "react-is-18": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "react-is-19": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
@@ -183,13 +183,9 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
   }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@b9g/libuild",
-  "version": "0.1.25",
+  "version": "0.2.0",
   "description": "Zero-config library builds",
-  "main": "./dist/src/libuild.cjs",
+  "main": "./dist/libuild.cjs",
   "bin": {
-    "libuild": "./dist/src/cli.js"
+    "libuild": "./dist/cli.js"
   },
   "type": "module",
   "scripts": {
@@ -55,69 +55,69 @@
     "url": "https://github.com/bikeshaving/libuild/issues"
   },
   "license": "MIT",
-  "module": "./dist/src/libuild.js",
-  "types": "./dist/src/libuild.d.ts",
+  "module": "./dist/libuild.js",
+  "types": "./dist/libuild.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/libuild.d.ts",
-      "import": "./dist/src/libuild.js"
+      "types": "./dist/libuild.d.ts",
+      "import": "./dist/libuild.js"
     },
     "./cli": {
-      "types": "./dist/src/cli.d.ts",
-      "import": "./dist/src/cli.js"
+      "types": "./dist/cli.d.ts",
+      "import": "./dist/cli.js"
     },
     "./cli.js": {
-      "types": "./dist/src/cli.d.ts",
-      "import": "./dist/src/cli.js"
+      "types": "./dist/cli.d.ts",
+      "import": "./dist/cli.js"
     },
     "./libuild": {
-      "types": "./dist/src/libuild.d.ts",
-      "import": "./dist/src/libuild.js"
+      "types": "./dist/libuild.d.ts",
+      "import": "./dist/libuild.js"
     },
     "./libuild.js": {
-      "types": "./dist/src/libuild.d.ts",
-      "import": "./dist/src/libuild.js"
+      "types": "./dist/libuild.d.ts",
+      "import": "./dist/libuild.js"
     },
     "./package.json": "./dist/package.json",
     "./test": {
-      "types": "./dist/src/test.d.ts",
-      "import": "./dist/src/test.js"
+      "types": "./dist/test.d.ts",
+      "import": "./dist/test.js"
     },
     "./test.js": {
-      "types": "./dist/src/test.d.ts",
-      "import": "./dist/src/test.js"
+      "types": "./dist/test.d.ts",
+      "import": "./dist/test.js"
     },
     "./test-bun": {
-      "types": "./dist/src/test-bun.d.ts",
-      "import": "./dist/src/test-bun.js"
+      "types": "./dist/test-bun.d.ts",
+      "import": "./dist/test-bun.js"
     },
     "./test-bun.js": {
-      "types": "./dist/src/test-bun.d.ts",
-      "import": "./dist/src/test-bun.js"
+      "types": "./dist/test-bun.d.ts",
+      "import": "./dist/test-bun.js"
     },
     "./test-node": {
-      "types": "./dist/src/test-node.d.ts",
-      "import": "./dist/src/test-node.js"
+      "types": "./dist/test-node.d.ts",
+      "import": "./dist/test-node.js"
     },
     "./test-node.js": {
-      "types": "./dist/src/test-node.d.ts",
-      "import": "./dist/src/test-node.js"
+      "types": "./dist/test-node.d.ts",
+      "import": "./dist/test-node.js"
     },
     "./test-browser": {
-      "types": "./dist/src/test-browser.d.ts",
-      "import": "./dist/src/test-browser.js"
+      "types": "./dist/test-browser.d.ts",
+      "import": "./dist/test-browser.js"
     },
     "./test-browser.js": {
-      "types": "./dist/src/test-browser.d.ts",
-      "import": "./dist/src/test-browser.js"
+      "types": "./dist/test-browser.d.ts",
+      "import": "./dist/test-browser.js"
     },
     "./test-runner": {
-      "types": "./dist/src/test-runner.d.ts",
-      "import": "./dist/src/test-runner.js"
+      "types": "./dist/test-runner.d.ts",
+      "import": "./dist/test-runner.js"
     },
     "./test-runner.js": {
-      "types": "./dist/src/test-runner.d.ts",
-      "import": "./dist/src/test-runner.js"
+      "types": "./dist/test-runner.d.ts",
+      "import": "./dist/test-runner.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "test": "bun test"
   },
   "dependencies": {
-    "commander": "^14.0.2",
-    "esbuild": "^0.19.0",
-    "expect": "^30.2.0",
-    "glob": "^13.0.0"
+    "commander": "^15.0.0",
+    "esbuild": "^0.28.1",
+    "expect": "^30.4.1",
+    "glob": "^13.0.6"
   },
   "peerDependencies": {
     "typescript": "^5.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,92 @@
 #!/usr/bin/env node
 import { Command } from "commander";
+import * as FS from "fs/promises";
 import * as Path from "path";
 import { build, publish } from "./libuild.ts";
 import { runTests, type Platform } from "./test-runner.ts";
+
+// =============================================================================
+// Publish argument validation
+// =============================================================================
+// The publish command forwards flags to `npm publish`, so its arguments are
+// validated against a strict whitelist to prevent command injection and
+// unsafe npm behavior (e.g. --ignore-scripts, --script-shell, --unsafe-perm).
+// Unknown flags and unexpected positional arguments are dropped with a
+// warning instead of being forwarded to npm.
+
+const ALLOWED_NPM_FLAGS = new Set([
+  "--dry-run", "--tag", "--access", "--registry", "--otp", "--provenance",
+  "--workspace", "--workspaces", "--include-workspace-root",
+]);
+
+// Allowed flags that consume a following value (when not written as --flag=value)
+const NPM_VALUE_FLAGS = new Set([
+  "--tag", "--access", "--registry", "--otp", "--workspace",
+]);
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    const stat = await FS.stat(path);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function runPublish(argv: string[]): Promise<void> {
+  // Remove the "publish" command token (first occurrence only)
+  const args = [...argv];
+  args.splice(args.indexOf("publish"), 1);
+
+  let save = true;
+  let directory: string | undefined;
+  const extraArgs: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    // libuild-level flags (not forwarded to npm)
+    if (arg === "--save") {
+      save = true;
+      continue;
+    }
+    if (arg === "--no-save") {
+      save = false;
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      const flagName = arg.split("=")[0]; // Handle --flag=value format
+      if (ALLOWED_NPM_FLAGS.has(flagName)) {
+        extraArgs.push(arg);
+        // If this flag expects a value and it's not --flag=value, consume the next argument
+        if (!arg.includes("=") && NPM_VALUE_FLAGS.has(flagName) &&
+            i + 1 < args.length && !args[i + 1].startsWith("-")) {
+          extraArgs.push(args[i + 1]);
+          i++;
+        }
+      } else {
+        console.warn(`Warning: Ignoring unknown/unsafe npm flag: ${arg}`);
+      }
+      continue;
+    }
+
+    // Non-flag argument: either the target directory or unexpected
+    if (directory === undefined && await isDirectory(Path.resolve(arg))) {
+      directory = arg;
+    } else {
+      console.warn(`Warning: Ignoring unexpected argument: ${arg}`);
+    }
+  }
+
+  const cwd = Path.resolve(directory ?? ".");
+  try {
+    await publish(cwd, save, extraArgs);
+  } catch (error: any) {
+    console.error("Error:", error?.message ?? error);
+    process.exit(1);
+  }
+}
 
 const program = new Command();
 
@@ -32,20 +116,12 @@ program
   .option("--registry <url>", "Use a specific registry")
   .option("--otp <code>", "One-time password for 2FA")
   .option("--provenance", "Generate provenance statement")
-  .action(async (directory: string, options: Record<string, any>) => {
-    const cwd = Path.resolve(directory);
-    const shouldSave = options.save !== false;
-
-    // Build npm publish args from options
-    const npmArgs: string[] = [];
-    if (options.dryRun) npmArgs.push("--dry-run");
-    if (options.tag) npmArgs.push("--tag", options.tag);
-    if (options.access) npmArgs.push("--access", options.access);
-    if (options.registry) npmArgs.push("--registry", options.registry);
-    if (options.otp) npmArgs.push("--otp", options.otp);
-    if (options.provenance) npmArgs.push("--provenance");
-
-    await publish(cwd, shouldSave, npmArgs);
+  .allowUnknownOption()
+  .allowExcessArguments()
+  .action(async () => {
+    // Publish uses whitelist-validated manual parsing (see runPublish) so
+    // unknown/unsafe npm flags are filtered with warnings instead of erroring.
+    await runPublish(process.argv.slice(2));
   });
 
 program
@@ -88,4 +164,18 @@ program
     process.exit(success ? 0 : 1);
   });
 
-program.parse();
+// Dispatch: the publish command bypasses commander's strict parsing so that
+// unknown/unsafe npm flags, stray arguments, and libuild flags in any position
+// (e.g. `libuild --save publish ...`) are handled by the whitelist validation
+// in runPublish. Everything else (build, test, help, version) uses commander.
+const cliArgs = process.argv.slice(2);
+const commandToken = cliArgs.find((arg) => !arg.startsWith("-"));
+
+if (commandToken === "publish" && !cliArgs.includes("--help") && !cliArgs.includes("-h")) {
+  runPublish(cliArgs).catch((error: any) => {
+    console.error("Error:", error?.message ?? error);
+    process.exit(1);
+  });
+} else {
+  program.parse();
+}

--- a/src/libuild.ts
+++ b/src/libuild.ts
@@ -950,7 +950,6 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
 
   const srcDir = Path.join(cwd, "src");
   const distDir = Path.join(cwd, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check src directory exists
   if (!await fileExists(srcDir)) {
@@ -1184,8 +1183,6 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     return name;
   };
 
-  let esmMetafile: ESBuild.Metafile | undefined;
-
   // Build all regular entries with smart dependency resolution
   if (entryPoints.length > 0) {
 
@@ -1208,11 +1205,10 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     const allEntryNames = [...srcEntryNames, ...binEntryNames];
 
     if (allESMEntryPoints.length > 0) {
-      const esmResult = await ESBuild.build({
+      await ESBuild.build({
         entryPoints: allESMEntryPoints.map(p => ({in: p, out: flatOut(p)})),
         outdir: distDir,
         chunkNames: "_chunks/[name]-[hash]", // Put chunks in a subdirectory
-        metafile: true, // Needed for compat stub generation (default export detection)
         format: "esm",
         outExtension: {".js": ".js"},
         bundle: true,
@@ -1245,7 +1241,6 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
           })] : [])
         ],
       });
-      esmMetafile = esmResult.metafile;
 
       // Check if code splitting created chunks and warn about CJS incompatibility
       if (options.formats.cjs) {
@@ -1353,90 +1348,6 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     });
   }
 
-  // Generate compatibility stubs under dist/src/.
-  // Earlier libuild versions published modules at src/<entry>.js; CDNs serve
-  // literal file paths (no exports-map resolution), so copy-pasted URLs like
-  // cdn.jsdelivr.net/npm/<pkg>/src/<entry>.js exist in the wild. Tiny
-  // forwarding modules keep those paths resolving after the move to the flat
-  // layout. The exports map only ever pointed at these files by value (keys
-  // were always ./<entry>), so Node consumers are unaffected either way.
-  {
-    // Map each entry source file to its ESM export names (via the metafile)
-    // so stubs only re-export `default` when it actually exists.
-    // Paths are realpath-normalized on both sides: esbuild resolves symlinks
-    // (e.g. /var -> /private/var on macOS) while our entry paths may not be.
-    const realpath = async (p: string): Promise<string> => {
-      try {
-        return await FS.realpath(p);
-      } catch {
-        return p;
-      }
-    };
-    const exportNamesByEntry = new Map<string, string[]>();
-    if (esmMetafile) {
-      for (const output of Object.values(esmMetafile.outputs)) {
-        if (output.entryPoint) {
-          exportNamesByEntry.set(await realpath(Path.resolve(output.entryPoint)), output.exports ?? []);
-        }
-      }
-    }
-
-    let stubCount = 0;
-    for (const entryPath of srcEntryPoints) {
-      const out = flatOut(entryPath); // "x" or "bin/x"
-      const realEntryPath = await realpath(Path.resolve(entryPath));
-      const stubPath = Path.join(distSrcDir, `${out}.js`);
-      const up = "../".repeat(out.split(Path.sep).length);
-      const target = `${up}${out.split(Path.sep).join("/")}`;
-
-      await FS.mkdir(Path.dirname(stubPath), {recursive: true});
-
-      // ESM stub (only if the real output exists - TLA fallbacks etc.)
-      if (await fileExists(Path.join(distDir, `${out}.js`))) {
-        const exportNames = exportNamesByEntry.get(realEntryPath) ?? [];
-        let stub = `export * from "${target}.js";\n`;
-        if (exportNames.includes("default")) {
-          stub += `export {default} from "${target}.js";\n`;
-        }
-        await FS.writeFile(stubPath, stub);
-        stubCount++;
-      }
-
-      // CJS stub
-      if (await fileExists(Path.join(distDir, `${out}.cjs`))) {
-        await FS.writeFile(
-          Path.join(distSrcDir, `${out}.cjs`),
-          `module.exports = require("${target}.cjs");\n`
-        );
-        stubCount++;
-      }
-
-      // Type declaration stub (module augmentations in the real .d.ts apply
-      // transitively through the re-export)
-      if (await fileExists(Path.join(distDir, `${out}.d.ts`))) {
-        const exportNames = exportNamesByEntry.get(realEntryPath) ?? [];
-        let stub = `export * from "${target}.js";\n`;
-        if (exportNames.includes("default")) {
-          stub += `export {default} from "${target}.js";\n`;
-        }
-        await FS.writeFile(Path.join(distSrcDir, `${out}.d.ts`), stub);
-        stubCount++;
-      }
-    }
-
-    // UMD is a browser <script> target - a re-export stub wouldn't work, so
-    // the compatibility file is a real copy of the (self-contained) build.
-    if (umdEntries.length > 0 && await fileExists(Path.join(distDir, "umd.js"))) {
-      await FS.mkdir(distSrcDir, {recursive: true});
-      await FS.copyFile(Path.join(distDir, "umd.js"), Path.join(distSrcDir, "umd.js"));
-      stubCount++;
-    }
-
-    if (stubCount > 0) {
-      console.info(`  Generating ${stubCount} src/ compatibility stub(s)...`);
-    }
-  }
-
   // TypeScript declarations and triple-slash references are now generated by the TypeScript plugin during ESM build
 
   // Initialize auto-discovered files tracking
@@ -1501,7 +1412,7 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     if (fixedDistPkg.files.length === 0) {
       delete fixedDistPkg.files;
     } else {
-      for (const pattern of ["*.js", "*.cjs", "*.d.ts", "src/", "bin/", "_chunks/"]) {
+      for (const pattern of ["*.js", "*.cjs", "*.d.ts", "bin/", "_chunks/"]) {
         if (!fixedDistPkg.files.includes(pattern)) {
           fixedDistPkg.files.push(pattern);
         }
@@ -1528,15 +1439,11 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
 
   // Copy ambient .d.ts files from src/ to the dist root (flat layout).
   // These are hand-written type declaration files, not generated by tsc.
-  // A compatibility copy is also placed under dist/src/ so previously
-  // published src/-relative paths keep resolving.
   if (ambientDtsFiles.length > 0) {
     console.info(`  Copying ${ambientDtsFiles.length} ambient .d.ts file(s)...`);
-    await FS.mkdir(distSrcDir, {recursive: true});
     for (const dtsFile of ambientDtsFiles) {
       const srcPath = Path.join(srcDir, dtsFile);
       await FS.copyFile(srcPath, Path.join(distDir, dtsFile));
-      await FS.copyFile(srcPath, Path.join(distSrcDir, dtsFile));
     }
   }
 
@@ -1703,8 +1610,7 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     // Clean up and validate bin paths based on actual built files.
     // transformBinPaths flattens any src/-shaped path (author "src/cli.js" or
     // previously saved "./dist/src/cli.js") to its flat dist location first -
-    // otherwise the path would resolve to the src/ compatibility STUB, which
-    // exists but is not the executable.
+    // the nested path no longer exists in the flat layout.
     if (rootPkg.bin) {
       if (typeof rootPkg.bin === "string") {
         const distPath = "./" + Path.join("dist", transformBinPaths(rootPkg.bin));

--- a/src/libuild.ts
+++ b/src/libuild.ts
@@ -292,9 +292,9 @@ async function generateExports(entries: string[], mainEntry: string | undefined,
       // Regular src entries get both ESM and CJS (if enabled)
       const exportEntry: any = {};
 
-      // Only include types if .d.ts file exists
+      // Only include types if .d.ts file exists (flat layout: dist root)
       if (distDir) {
-        const dtsPath = Path.join(distDir, "src", `${entry}.d.ts`);
+        const dtsPath = Path.join(distDir, `${entry}.d.ts`);
         const exists = await fileExists(dtsPath);
         if (exists) {
           exportEntry.types = `./src/${entry}.d.ts`;
@@ -317,9 +317,10 @@ async function generateExports(entries: string[], mainEntry: string | undefined,
         return existing;
       }
 
-      // Special case for ambient .d.ts files - they're just copied, not built
-      // They can be in ./src/ or ./dist/src/ depending on context (root vs dist package.json)
-      if (existing.endsWith('.d.ts') && (existing.match(/\.\/(?:dist\/)?src\/[^/]+\.d\.ts$/))) {
+      // Special case for ambient .d.ts files - they're just copied, not built.
+      // Accepted forms: ./x.d.ts, ./dist/x.d.ts (flat layout) and the legacy
+      // ./src/x.d.ts, ./dist/src/x.d.ts (round-trips from older saves)
+      if (existing.endsWith('.d.ts') && (existing.match(/^\.\/(?:dist\/)?(?:src\/)?[^/]+\.d\.ts$/))) {
         return existing;
       }
 
@@ -543,10 +544,14 @@ async function validateSingleBinPath(binPath: string, fieldName: string, cwd: st
     return;
   }
   
-  // Check other dist/ patterns that aren't libuild's standard output
+  // Check other dist/ patterns - in the flat layout, ./dist/<entry>.js is
+  // valid libuild output, so accept it when the built file exists
   if (binPath.startsWith("dist/") || binPath.startsWith("./dist/")) {
+    if (await fileExists(Path.join(cwd, binPath))) {
+      return;
+    }
     console.warn(`⚠️  WARNING: ${fieldName} field points to "${binPath}" in dist/ directory.
-   
+
    libuild expects bin entries to point to src/ files. Consider changing to the corresponding src/ path and using --save.`);
     return;
   }
@@ -599,33 +604,21 @@ async function validateSingleBinPath(binPath: string, fieldName: string, cwd: st
 
 function transformBinPaths(value: any): any {
   if (typeof value === "string") {
-    // Transform ./dist/src/ paths to src/ without ./ prefix for npm conventions
-    if (value.startsWith("./dist/src/")) {
-      return value.replace("./dist/", "");
-    }
-    // Transform dist/src/ paths to src/ without ./ prefix for npm conventions  
-    if (value.startsWith("dist/src/")) {
-      return value.replace("dist/", "");
-    }
-    // Transform ./dist/bin/ paths to bin/ without ./ prefix for npm conventions
-    if (value.startsWith("./dist/bin/")) {
-      return value.replace("./dist/", "");
-    }
-    // Transform dist/bin/ paths to bin/ without ./ prefix for npm conventions  
-    if (value.startsWith("dist/bin/")) {
-      return value.replace("dist/", "");
-    }
-    // Transform ./src/ paths (including nested) to src/ without ./ prefix for npm conventions
-    if (value.startsWith("./src/")) {
-      return value.replace("./", "");
-    }
-    // Transform ./bin/ paths to bin/ without ./ prefix for npm conventions
-    if (value.startsWith("./bin/")) {
-      return value.replace("./", "");
-    }
-    // Don't add ./ prefix for src/ or bin/ paths
-    if (value.startsWith("src/") || value === "src" || value.startsWith("bin/") || value === "bin") {
-      return value;
+    // Normalize to the flat dist layout (paths are relative to the dist
+    // package.json, no ./ prefix per npm conventions):
+    //   (./)(dist/)*src/bin/x -> bin/x
+    //   (./)(dist/)*src/x     -> x
+    //   (./)(dist/)*bin/x     -> bin/x
+    //   (./)(dist/)*x         -> x
+    const match = value.match(/^(?:\.\/)?((?:dist\/)+)?(.*)$/);
+    if (match && match[2].length > 0) {
+      let rest = match[2];
+      if (rest.startsWith("src/bin/")) {
+        rest = "bin/" + rest.slice("src/bin/".length);
+      } else if (rest.startsWith("src/") && rest.length > "src/".length) {
+        rest = rest.slice("src/".length);
+      }
+      return rest;
     }
     return value;
   } else if (typeof value === "object" && value !== null) {
@@ -640,25 +633,32 @@ function transformBinPaths(value: any): any {
 
 function fixExportsForDist(obj: any): any {
   if (typeof obj === "string") {
-    // Fix paths that incorrectly have ./dist/dist/dist/... -> ./src/
-    if (obj.includes("/dist/") && obj.includes("/src/")) {
-      // Extract everything after the last /src/
-      const match = obj.match(/.*\/src\/(.*)$/);
-      if (match) {
-        return `./src/${match[1]}`;
-      }
-    }
-    // Fix paths that incorrectly start with ./dist/src/ -> ./src/
-    if (obj.startsWith("./dist/src/")) {
-      return obj.replace("./dist/src/", "./src/");
-    }
-    // Fix paths that incorrectly start with ./dist/bin/ -> ./bin/
-    if (obj.startsWith("./dist/bin/")) {
-      return obj.replace("./dist/bin/", "./bin/");
-    }
     // Fix package.json path
-    if (obj.includes("/dist/") && obj.endsWith("/package.json")) {
+    if (obj.includes("dist/") && obj.endsWith("/package.json")) {
       return "./package.json";
+    }
+    // Relocate paths into the flat dist layout:
+    //   (./)(dist/)*src/bin/x -> (./)bin/x
+    //   (./)(dist/)*src/x     -> (./)x
+    //   (./)(dist/)*bin/x     -> (./)bin/x
+    //   (./)(dist/)*x         -> (./)x
+    // The original "./" prefix (or its absence) is preserved.
+    const match = obj.match(/^(\.\/)?((?:dist\/)+)?(.*)$/);
+    if (match) {
+      const dotSlash = match[1] ?? "";
+      const hadDistPrefix = match[2] !== undefined;
+      let rest = match[3];
+      let changed = hadDistPrefix;
+      if (rest.startsWith("src/bin/")) {
+        rest = "bin/" + rest.slice("src/bin/".length);
+        changed = true;
+      } else if (rest.startsWith("src/") && rest.length > "src/".length) {
+        rest = rest.slice("src/".length);
+        changed = true;
+      }
+      if (changed && rest.length > 0) {
+        return dotSlash + rest;
+      }
     }
     return obj;
   } else if (Array.isArray(obj)) {
@@ -668,8 +668,12 @@ function fixExportsForDist(obj: any): any {
     for (const [key, val] of Object.entries(obj)) {
       // Handle special cases for package.json fields
       if (key === "files" && Array.isArray(val)) {
-        // For files field in dist package.json, remove "dist/" entries since we're already in dist
-        fixed[key] = val.filter((file: string) => file !== "dist/" && file !== "dist").concat(val.includes("dist/") || val.includes("dist") ? ["src/"] : []);
+        // In the flat layout the built modules live at the dist root, which a
+        // files whitelist cannot express as a directory. Drop layout entries;
+        // the caller removes the field entirely if nothing author-specified remains.
+        // Other entries are copied verbatim into dist, so keep them untransformed.
+        fixed[key] = val
+          .filter((file: string) => !["dist", "dist/", "src", "src/"].includes(file));
       } else if (key === "bin") {
         // Don't transform bin field - it's already been processed by transformBinPaths
         fixed[key] = val;
@@ -722,7 +726,8 @@ async function makeFilesExecutable(pkg: PackageJSON, cwd: string, allBinEntries:
   // All files built from bin/ directories
   const binDirFiles = new Set<string>();
   for (const binEntryInfo of allBinEntries) {
-    const baseDir = binEntryInfo.source === 'src' ? "dist/src/bin" : "dist/bin";
+    // Flat layout: both src/bin/ and top-level bin/ entries output to dist/bin/
+    const baseDir = "dist/bin";
     const jsPath = Path.join(cwd, baseDir, `${binEntryInfo.name}.js`);
     const cjsPath = Path.join(cwd, baseDir, `${binEntryInfo.name}.cjs`);
 
@@ -894,9 +899,9 @@ async function cleanPackageJSON(pkg: PackageJSON, mainEntry: string | undefined,
     }
     cleaned.module = `src/${mainEntry}.js`;
 
-    // Only include types field if .d.ts file exists
+    // Only include types field if .d.ts file exists (flat layout: dist root)
     if (distDir) {
-      const dtsPath = Path.join(distDir, "src", `${mainEntry}.d.ts`);
+      const dtsPath = Path.join(distDir, `${mainEntry}.d.ts`);
       const exists = await fileExists(dtsPath);
       if (exists) {
         cleaned.types = `src/${mainEntry}.d.ts`;
@@ -998,14 +1003,19 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
   if (pkg.exports && typeof pkg.exports === 'object') {
     // Check if exports contains multiple src/ entry points beyond "."
     // (we handle "." separately via hasCustomMain check)
+    // Entry references come in two shapes: author paths ("./src/utils.js")
+    // and flat saved paths ("./dist/utils.js" or "./utils.js" after --save)
+    const referencesEntry = (v: unknown): boolean =>
+      typeof v === 'string' &&
+      (v.includes('/src/') || /^\.\/(?:dist\/)?[^/]+\.(?:js|cjs|ts|d\.ts)$/.test(v));
     const srcExportKeys = Object.keys(pkg.exports).filter(key => {
       // Skip "." and package.json exports
       if (key === "." || key === "./package.json") return false;
       // Look for exports that reference src/ files (like ./api, ./utils)
       const val = pkg.exports[key];
-      if (typeof val === 'string') return val.includes('/src/');
+      if (typeof val === 'string') return referencesEntry(val);
       if (typeof val === 'object' && val !== null) {
-        return Object.values(val).some(v => typeof v === 'string' && v.includes('/src/'));
+        return Object.values(val).some(referencesEntry);
       }
       return false;
     });
@@ -1158,9 +1168,27 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     await FS.mkdir(distBinDir, {recursive: true});
   }
 
+  // Flat output layout:
+  //   src/<entry>     -> dist/<entry>       (tarball root)
+  //   src/bin/<entry> -> dist/bin/<entry>
+  //   bin/<entry>     -> dist/bin/<entry>
+  // Explicit {in, out} entry points replace outbase-based structure preservation.
+  const flatOut = (entryPath: string): string => {
+    const name = Path.basename(entryPath, Path.extname(entryPath));
+    if (entryPath.startsWith(Path.join(srcDir, "bin") + Path.sep)) {
+      return Path.join("bin", name);
+    }
+    if (entryPath.startsWith(binDir + Path.sep)) {
+      return Path.join("bin", name);
+    }
+    return name;
+  };
+
+  let esmMetafile: ESBuild.Metafile | undefined;
+
   // Build all regular entries with smart dependency resolution
   if (entryPoints.length > 0) {
-    
+
     // ESM build - build src and bin entries separately to different output directories
     console.info(`  Building ${entryPoints.length} entries (ESM)...`);
 
@@ -1176,16 +1204,15 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     });
 
     // Build all ESM entries (src + bin) in a single batch
-    // Using outbase allows ESBuild to preserve src/ and bin/ directory structure
     const allESMEntryPoints = [...srcEntryPoints, ...binEntryPoints];
     const allEntryNames = [...srcEntryNames, ...binEntryNames];
 
     if (allESMEntryPoints.length > 0) {
-      await ESBuild.build({
-        entryPoints: allESMEntryPoints,
+      const esmResult = await ESBuild.build({
+        entryPoints: allESMEntryPoints.map(p => ({in: p, out: flatOut(p)})),
         outdir: distDir,
-        outbase: cwd, // Preserve src/ and bin/ directory structure
-        chunkNames: "src/_chunks/[name]-[hash]", // Put chunks in a subdirectory
+        chunkNames: "_chunks/[name]-[hash]", // Put chunks in a subdirectory
+        metafile: true, // Needed for compat stub generation (default export detection)
         format: "esm",
         outExtension: {".js": ".js"},
         bundle: true,
@@ -1203,8 +1230,10 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
             outputExtension: ".js"
           }),
           // Generate TypeScript declarations for src entries
+          // rootDir: srcDir + outDir: distDir means src/x.ts -> dist/x.d.ts
+          // and src/bin/x.ts -> dist/bin/x.d.ts (flat layout)
           ...(srcEntryPoints.length > 0 ? [dtsPlugin({
-            outDir: distSrcDir,
+            outDir: distDir,
             rootDir: srcDir,
             entryPoints: srcEntryPoints
           })] : []),
@@ -1216,11 +1245,12 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
           })] : [])
         ],
       });
+      esmMetafile = esmResult.metafile;
 
       // Check if code splitting created chunks and warn about CJS incompatibility
       if (options.formats.cjs) {
         // Look for chunk files in the _chunks subdirectory
-        const chunksDir = Path.join(distSrcDir, "_chunks");
+        const chunksDir = Path.join(distDir, "_chunks");
         const chunksExist = await FS.stat(chunksDir).then(() => true, () => false);
         if (chunksExist) {
           const chunkFiles = await FS.readdir(chunksDir);
@@ -1253,8 +1283,8 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
       if (srcEntryPoints.length > 0) {
         try {
           await ESBuild.build({
-            entryPoints: srcEntryPoints,
-            outdir: distSrcDir,
+            entryPoints: srcEntryPoints.map(p => ({in: p, out: flatOut(p)})),
+            outdir: distDir,
             format: "cjs",
             outExtension: {".js": ".cjs"},
             bundle: true,
@@ -1310,7 +1340,7 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
 
     await ESBuild.build({
       entryPoints: [umdPath],
-      outdir: distSrcDir,
+      outfile: Path.join(distDir, "umd.js"),
       format: "cjs",
       bundle: true,
       minify: false,
@@ -1321,6 +1351,90 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
       supported: { "import-attributes": true },
       plugins: [umdPlugin({globalName})],
     });
+  }
+
+  // Generate compatibility stubs under dist/src/.
+  // Earlier libuild versions published modules at src/<entry>.js; CDNs serve
+  // literal file paths (no exports-map resolution), so copy-pasted URLs like
+  // cdn.jsdelivr.net/npm/<pkg>/src/<entry>.js exist in the wild. Tiny
+  // forwarding modules keep those paths resolving after the move to the flat
+  // layout. The exports map only ever pointed at these files by value (keys
+  // were always ./<entry>), so Node consumers are unaffected either way.
+  {
+    // Map each entry source file to its ESM export names (via the metafile)
+    // so stubs only re-export `default` when it actually exists.
+    // Paths are realpath-normalized on both sides: esbuild resolves symlinks
+    // (e.g. /var -> /private/var on macOS) while our entry paths may not be.
+    const realpath = async (p: string): Promise<string> => {
+      try {
+        return await FS.realpath(p);
+      } catch {
+        return p;
+      }
+    };
+    const exportNamesByEntry = new Map<string, string[]>();
+    if (esmMetafile) {
+      for (const output of Object.values(esmMetafile.outputs)) {
+        if (output.entryPoint) {
+          exportNamesByEntry.set(await realpath(Path.resolve(output.entryPoint)), output.exports ?? []);
+        }
+      }
+    }
+
+    let stubCount = 0;
+    for (const entryPath of srcEntryPoints) {
+      const out = flatOut(entryPath); // "x" or "bin/x"
+      const realEntryPath = await realpath(Path.resolve(entryPath));
+      const stubPath = Path.join(distSrcDir, `${out}.js`);
+      const up = "../".repeat(out.split(Path.sep).length);
+      const target = `${up}${out.split(Path.sep).join("/")}`;
+
+      await FS.mkdir(Path.dirname(stubPath), {recursive: true});
+
+      // ESM stub (only if the real output exists - TLA fallbacks etc.)
+      if (await fileExists(Path.join(distDir, `${out}.js`))) {
+        const exportNames = exportNamesByEntry.get(realEntryPath) ?? [];
+        let stub = `export * from "${target}.js";\n`;
+        if (exportNames.includes("default")) {
+          stub += `export {default} from "${target}.js";\n`;
+        }
+        await FS.writeFile(stubPath, stub);
+        stubCount++;
+      }
+
+      // CJS stub
+      if (await fileExists(Path.join(distDir, `${out}.cjs`))) {
+        await FS.writeFile(
+          Path.join(distSrcDir, `${out}.cjs`),
+          `module.exports = require("${target}.cjs");\n`
+        );
+        stubCount++;
+      }
+
+      // Type declaration stub (module augmentations in the real .d.ts apply
+      // transitively through the re-export)
+      if (await fileExists(Path.join(distDir, `${out}.d.ts`))) {
+        const exportNames = exportNamesByEntry.get(realEntryPath) ?? [];
+        let stub = `export * from "${target}.js";\n`;
+        if (exportNames.includes("default")) {
+          stub += `export {default} from "${target}.js";\n`;
+        }
+        await FS.writeFile(Path.join(distSrcDir, `${out}.d.ts`), stub);
+        stubCount++;
+      }
+    }
+
+    // UMD is a browser <script> target - a re-export stub wouldn't work, so
+    // the compatibility file is a real copy of the (self-contained) build.
+    if (umdEntries.length > 0 && await fileExists(Path.join(distDir, "umd.js"))) {
+      await FS.mkdir(distSrcDir, {recursive: true});
+      await FS.copyFile(Path.join(distDir, "umd.js"), Path.join(distSrcDir, "umd.js"));
+      stubCount++;
+    }
+
+    if (stubCount > 0) {
+      console.info(`  Generating ${stubCount} src/ compatibility stub(s)...`);
+    }
   }
 
   // TypeScript declarations and triple-slash references are now generated by the TypeScript plugin during ESM build
@@ -1378,6 +1492,23 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
   // Apply path fixes to the dist package.json
   const fixedDistPkg = fixExportsForDist(cleanedPkg);
 
+  // In the flat layout the built modules live at the dist root, which a files
+  // whitelist cannot express as a single directory. If nothing author-specified
+  // remains, drop the field (npm then packs the whole directory - which is
+  // exactly the built output). If author extras remain, append patterns
+  // covering the built modules so the whitelist doesn't exclude them.
+  if (fixedDistPkg.files && Array.isArray(fixedDistPkg.files)) {
+    if (fixedDistPkg.files.length === 0) {
+      delete fixedDistPkg.files;
+    } else {
+      for (const pattern of ["*.js", "*.cjs", "*.d.ts", "src/", "bin/", "_chunks/"]) {
+        if (!fixedDistPkg.files.includes(pattern)) {
+          fixedDistPkg.files.push(pattern);
+        }
+      }
+    }
+  }
+
   await FS.writeFile(
     Path.join(distDir, "package.json"),
     JSON.stringify(fixedDistPkg, null, 2) + "\n"
@@ -1395,14 +1526,17 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     }
   }
 
-  // Copy ambient .d.ts files from src/ to dist/src/
-  // These are hand-written type declaration files, not generated by tsc
+  // Copy ambient .d.ts files from src/ to the dist root (flat layout).
+  // These are hand-written type declaration files, not generated by tsc.
+  // A compatibility copy is also placed under dist/src/ so previously
+  // published src/-relative paths keep resolving.
   if (ambientDtsFiles.length > 0) {
     console.info(`  Copying ${ambientDtsFiles.length} ambient .d.ts file(s)...`);
+    await FS.mkdir(distSrcDir, {recursive: true});
     for (const dtsFile of ambientDtsFiles) {
       const srcPath = Path.join(srcDir, dtsFile);
-      const destPath = Path.join(distSrcDir, dtsFile);
-      await FS.copyFile(srcPath, destPath);
+      await FS.copyFile(srcPath, Path.join(distDir, dtsFile));
+      await FS.copyFile(srcPath, Path.join(distSrcDir, dtsFile));
     }
   }
 
@@ -1489,16 +1623,16 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     }
     rootPkg.scripts.prepublishOnly = "echo 'ERROR: Cannot publish from root directory. Use libuild publish instead.' && exit 1";
 
-    // Update main/module/types to point to dist
+    // Update main/module/types to point to dist (flat layout)
     if (options.formats.cjs) {
-      rootPkg.main = `./dist/src/${mainEntry}.cjs`;
+      rootPkg.main = `./dist/${mainEntry}.cjs`;
     }
-    rootPkg.module = `./dist/src/${mainEntry}.js`;
-    
+    rootPkg.module = `./dist/${mainEntry}.js`;
+
     // Only include types field if .d.ts file exists
-    const dtsPath = Path.join(distDir, "src", `${mainEntry}.d.ts`);
+    const dtsPath = Path.join(distDir, `${mainEntry}.d.ts`);
     if (await fileExists(dtsPath)) {
-      rootPkg.types = `./dist/src/${mainEntry}.d.ts`;
+      rootPkg.types = `./dist/${mainEntry}.d.ts`;
     }
 
     if (rootPkg.typings && typeof rootPkg.typings === "string") {
@@ -1541,9 +1675,8 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
     if (allBinEntries.length > 0) {
       const generatedBin: any = {};
       for (const binEntryInfo of allBinEntries) {
-        const binPath = binEntryInfo.source === 'src' 
-          ? `./dist/src/bin/${binEntryInfo.name}.js`
-          : `./dist/bin/${binEntryInfo.name}.js`;
+        // Flat layout: both src/bin/ and top-level bin/ entries output to dist/bin/
+        const binPath = `./dist/bin/${binEntryInfo.name}.js`;
         const fullPath = Path.join(cwd, binPath);
         // Only add if the file actually exists
         if (await fileExists(fullPath)) {
@@ -1567,12 +1700,14 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
       }
     }
 
-    // Clean up and validate bin paths based on actual built files
+    // Clean up and validate bin paths based on actual built files.
+    // transformBinPaths flattens any src/-shaped path (author "src/cli.js" or
+    // previously saved "./dist/src/cli.js") to its flat dist location first -
+    // otherwise the path would resolve to the src/ compatibility STUB, which
+    // exists but is not the executable.
     if (rootPkg.bin) {
       if (typeof rootPkg.bin === "string") {
-        const distPath = rootPkg.bin.startsWith("./dist/") ? rootPkg.bin : 
-                        rootPkg.bin.startsWith("dist/") ? "./" + rootPkg.bin :
-                        "./" + Path.join("dist", rootPkg.bin);
+        const distPath = "./" + Path.join("dist", transformBinPaths(rootPkg.bin));
         const fullPath = Path.join(cwd, distPath);
         // Only keep if the file actually exists
         if (await fileExists(fullPath)) {
@@ -1584,9 +1719,7 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
         const cleanedBin: any = {};
         for (const [name, binPath] of Object.entries(rootPkg.bin)) {
           if (typeof binPath === "string") {
-            const distPath = binPath.startsWith("./dist/") ? binPath :
-                            binPath.startsWith("dist/") ? "./" + binPath :
-                            "./" + Path.join("dist", binPath);
+            const distPath = "./" + Path.join("dist", transformBinPaths(binPath));
             const fullPath = Path.join(cwd, distPath);
             // Only include if the file actually exists
             if (await fileExists(fullPath)) {

--- a/src/libuild.ts
+++ b/src/libuild.ts
@@ -52,7 +52,7 @@ async function processJavaScriptExecutable(filePath: string, runtimeBanner: stri
     if (modified) {
       await FS.writeFile(filePath, lines.join('\n'));
     }
-  } catch (error) {
+  } catch (error: any) {
     console.warn(`⚠️  WARNING: Could not process executable ${filePath}: ${error.message}`);
   }
 }
@@ -82,7 +82,7 @@ interface BuildOptions {
 }
 
 function isValidEntrypoint(filename: string): boolean {
-  if (!filename.endsWith(".ts") && !filename.endsWith(".js")) return false;
+  if (!filename.endsWith(".ts") && !filename.endsWith(".tsx") && !filename.endsWith(".js")) return false;
   if (filename.endsWith(".d.ts")) return false; // Ignore TypeScript declaration files
   if (filename.startsWith("_")) return false;
   if (filename.startsWith(".")) return false;
@@ -106,6 +106,8 @@ async function findEntrypoints(srcDir: string): Promise<string[]> {
       return isValidEntrypoint(dirent.name);
     })
     .map(dirent => Path.basename(dirent.name, Path.extname(dirent.name)))
+    // Dedupe basenames (e.g. x.ts + x.tsx); entry resolution picks by extension order
+    .filter((name, i, names) => names.indexOf(name) === i)
     .sort();
 }
 
@@ -121,7 +123,7 @@ async function findBinEntrypoints(binDir: string): Promise<string[]> {
       })
       .map(dirent => Path.basename(dirent.name, Path.extname(dirent.name)))
       .sort();
-  } catch (error) {
+  } catch (error: any) {
     // If bin directory doesn't exist, return empty array
     if (error.code === 'ENOENT') {
       return [];
@@ -267,7 +269,7 @@ function checkIfExportIsStale(exportKey: string, exportValue: any, entries: stri
   return entryName ? !entries.includes(entryName) : false;
 }
 
-async function generateExports(entries: string[], mainEntry: string | undefined, options: BuildOptions, existingExports: any = {}, distDir?: string, allBinEntries: Array<{name: string, source: string}> = []): Promise<{exports: any, staleExports: string[]}> {
+async function generateExports(entries: string[], mainEntry: string | undefined, options: BuildOptions, existingExports: any = {}, distDir?: string): Promise<{exports: any, staleExports: string[]}> {
   const exports: any = {};
   const staleExports: string[] = [];
 
@@ -387,6 +389,20 @@ async function generateExports(entries: string[], mainEntry: string | undefined,
 
         throw new Error(`Export import path '${existing.import}' must point to a valid entrypoint in src/ (e.g., './src/utils.js'). Nested directories and internal files are not allowed.`);
       }
+      // Fill in any missing conditions from the entry (#7: a types-only "."
+      // export must still get its import - and require when CJS is enabled -
+      // or bundlers can't resolve the package at all)
+      if (entryFromPath) {
+        const filled: any = {
+          types: existing.types || `./src/${entryFromPath}.d.ts`,
+          import: existing.import || `./src/${entryFromPath}.js`,
+          ...existing,
+        };
+        if (options.formats.cjs && !filled.require) {
+          filled.require = `./src/${entryFromPath}.cjs`;
+        }
+        return filled;
+      }
       return {
         types: existing.types || `./src/${entryFromPath}.d.ts`,
         ...existing,
@@ -504,23 +520,17 @@ async function validateSingleBinPath(binPath: string, fieldName: string, cwd: st
     
     // Extract the corresponding src/ or bin/ path to suggest
     let srcPath: string;
-    let sourceDir: string;
-    
+
     if (binPath.startsWith("./dist/src/")) {
       srcPath = binPath.replace("./dist/src/", "src/");
-      sourceDir = "src";
     } else if (binPath.startsWith("dist/src/")) {
       srcPath = binPath.replace("dist/src/", "src/");
-      sourceDir = "src";
     } else if (binPath.startsWith("./dist/bin/")) {
       srcPath = binPath.replace("./dist/bin/", "bin/");
-      sourceDir = "bin";
     } else if (binPath.startsWith("dist/bin/")) {
       srcPath = binPath.replace("dist/bin/", "bin/");
-      sourceDir = "bin";
     } else {
       srcPath = binPath;
-      sourceDir = "src";
     }
       
     // Check if source file exists
@@ -689,7 +699,7 @@ function fixExportsForDist(obj: any): any {
 async function setExecutablePermissions(filePath: string): Promise<void> {
   try {
     await FS.chmod(filePath, 0o755);
-  } catch (error) {
+  } catch (error: any) {
     console.warn(`⚠️  WARNING: Could not set executable permissions for ${filePath}: ${error.message}`);
   }
 }
@@ -823,7 +833,7 @@ async function resolveWorkspaceVersion(packageName: string, workspaceSpec: strin
     }
     
     return workspaceSpec;
-  } catch (error) {
+  } catch (error: any) {
     console.warn(`⚠️  WARNING: Error resolving workspace dependency "${packageName}": ${error.message}`);
     return workspaceSpec;
   }
@@ -1078,7 +1088,7 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
   }
 
   // Clean dist directory atomically using a temporary directory
-  const tempDistDir = `${distDir}.tmp.${Date.now()}.${Math.random().toString(36).substr(2, 9)}`;
+  const tempDistDir = `${distDir}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 11)}`;
   
   try {
     // Create temporary directory
@@ -1115,37 +1125,23 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
   const umdEntries: string[] = [];
 
   for (const entry of entries) {
-    let entryPath: string;
-    let jsEntryPath: string;
-    let sourceDir: string;
-    
-    if (entry.startsWith("bin/")) {
-      // Handle bin/ entries - need to determine if from top-level bin/ or src/bin/
-      const binEntryName = entry.replace("bin/", "");
-      const binEntryInfo = allBinEntries.find(binEntry => binEntry.name === binEntryName);
-      
-      if (binEntryInfo?.source === 'src') {
-        // This is a src/bin/ entry
-        entryPath = Path.join(srcDir, "bin", `${binEntryName}.ts`);
-        jsEntryPath = Path.join(srcDir, "bin", `${binEntryName}.js`);
-        sourceDir = "src/bin/";
-      } else {
-        // This is a top-level bin/ entry
-        entryPath = Path.join(binDir, `${binEntryName}.ts`);
-        jsEntryPath = Path.join(binDir, `${binEntryName}.js`);
-        sourceDir = "bin/";
-      }
-    } else {
-      // Handle src/ entries (existing logic)
-      entryPath = Path.join(srcDir, `${entry}.ts`);
-      jsEntryPath = Path.join(srcDir, `${entry}.js`);
-      sourceDir = "src/";
-    }
-    
-    const actualPath = await fileExists(entryPath) ? entryPath : jsEntryPath;
+    // Resolve the entry source file, trying extensions in order
+    const isBin = entry.startsWith("bin/");
+    const baseName = entry.replace("bin/", "");
+    const baseDir = isBin ? binDir : srcDir;
+    const sourceDir = isBin ? "bin/" : "src/";
 
-    if (!await fileExists(actualPath)) {
-      throw new Error(`Entry point file not found: ${actualPath}. Expected ${entry.replace("bin/", "")}.ts or ${entry.replace("bin/", "")}.js in ${sourceDir} directory.`);
+    let actualPath: string | undefined;
+    for (const ext of [".ts", ".tsx", ".js"]) {
+      const candidate = Path.join(baseDir, `${baseName}${ext}`);
+      if (await fileExists(candidate)) {
+        actualPath = candidate;
+        break;
+      }
+    }
+
+    if (!actualPath) {
+      throw new Error(`Entry point file not found for "${entry}". Expected ${baseName}.ts, ${baseName}.tsx, or ${baseName}.js in ${sourceDir} directory.`);
     }
 
     if (entry === "umd") {
@@ -1363,7 +1359,7 @@ export async function build(cwd: string, save: boolean = false): Promise<{distPk
   // Generate package.json
   console.info("  Generating package.json...");
   const cleanedPkg = await cleanPackageJSON(pkg, mainEntry, options, cwd, distDir);
-  const exportsResult = await generateExports(entries, mainEntry, options, pkg.exports, distDir, allBinEntries);
+  const exportsResult = await generateExports(entries, mainEntry, options, pkg.exports, distDir);
 
   // Add ambient .d.ts files to exports BEFORE fixExportsForDist
   for (const dtsFile of ambientDtsFiles) {

--- a/src/plugins/dts.ts
+++ b/src/plugins/dts.ts
@@ -52,7 +52,7 @@ export function dtsPlugin(options: TypeScriptPluginOptions): ESBuild.Plugin {
         // This includes internal modules so their .d.ts files are generated
         // Filter to only files within rootDir to prevent emitting .d.ts to wrong locations
         const tsFiles = entryFiles
-          .filter(file => file.endsWith('.ts') && !file.endsWith('.d.ts'))
+          .filter(file => (file.endsWith('.ts') || file.endsWith('.tsx')) && !file.endsWith('.d.ts'))
           .map(f => fs.realpathSync(f))
           .filter(f => f.startsWith(resolvedRootDir + Path.sep));
 
@@ -74,6 +74,25 @@ export function dtsPlugin(options: TypeScriptPluginOptions): ESBuild.Plugin {
             module: TS.ModuleKind.ESNext,
             moduleResolution: TS.ModuleResolutionKind.Bundler,
           };
+
+          // .tsx entries need a jsx setting to parse. Honor the project's
+          // tsconfig (jsx/jsxImportSource/jsxFactory) like esbuild does;
+          // fall back to preserve, which needs no runtime resolution.
+          if (tsFiles.some(f => f.endsWith('.tsx'))) {
+            compilerOptions.jsx = TS.JsxEmit.Preserve;
+            const configPath = TS.findConfigFile(resolvedRootDir, TS.sys.fileExists);
+            if (configPath) {
+              const configFile = TS.readConfigFile(configPath, TS.sys.readFile);
+              if (!configFile.error) {
+                const parsed = TS.parseJsonConfigFileContent(configFile.config, TS.sys, Path.dirname(configPath));
+                for (const key of ["jsx", "jsxImportSource", "jsxFactory", "jsxFragmentFactory"] as const) {
+                  if (parsed.options[key] !== undefined) {
+                    (compilerOptions as any)[key] = parsed.options[key];
+                  }
+                }
+              }
+            }
+          }
 
           // Create program with explicit config to avoid tsconfig.json interference
           const program = TS.createProgram(resolvedTsFiles, compilerOptions);

--- a/src/plugins/external.ts
+++ b/src/plugins/external.ts
@@ -6,6 +6,20 @@ export interface ExternalEntrypointsOptions {
   outputExtension: string;
 }
 
+// Output layout (flat):
+//   src/<entry>      -> <entry>        (dist root)
+//   src/bin/<entry>  -> bin/<entry>
+//   bin/<entry>      -> bin/<entry>
+// Import rewrites must account for the importer's OUTPUT location, which no
+// longer mirrors its source location for src/ files.
+function importerOutputDir(importer: string): "root" | "bin" {
+  // src/bin/x.ts and bin/x.ts both output to dist/bin/
+  if (/[/\\](?:src[/\\])?bin[/\\][^/\\]+$/.test(importer)) {
+    return "bin";
+  }
+  return "root";
+}
+
 export function externalEntrypointsPlugin(options: ExternalEntrypointsOptions): ESBuild.Plugin {
   return {
     name: "external-entrypoints",
@@ -19,6 +33,8 @@ export function externalEntrypointsPlugin(options: ExternalEntrypointsOptions): 
         : entryNames;
 
       // Mark same-directory entry points as external (./foo, ./bar)
+      // Same source directory means same output directory in the flat layout,
+      // so the relative path is unchanged.
       build.onResolve({filter: /^\.\//}, args => {
         const withoutExt = args.path.replace(/\.(ts|js)$/, '');
         const entryName = withoutExt.replace(/^\.\//, '');
@@ -35,15 +51,31 @@ export function externalEntrypointsPlugin(options: ExternalEntrypointsOptions): 
       // Only externalize if the imported file is an actual entry point
       build.onResolve({filter: /^\.\.\/(?:src|bin)\//}, args => {
         const withoutExt = args.path.replace(/\.(ts|js)$/, '');
-        // Extract just the filename from paths like ../src/index or ../bin/cli
-        const match = withoutExt.match(/^\.\.\/(?:src|bin)\/(.+)$/);
+        const match = withoutExt.match(/^\.\.\/(src|bin)\/(.+)$/);
         if (match) {
-          const entryName = match[1];
+          const dir = match[1];
+          const entryName = match[2];
           if (externalEntries.includes(entryName)) {
-            // This is an entry point, externalize it
-            const dir = withoutExt.match(/^(\.\.\/(?:src|bin))\//)?.[1];
+            // Compute the output-relative path in the flat layout
+            const importerDir = importerOutputDir(args.importer);
+            let outPath: string;
+            if (dir === "src") {
+              // Target src entry outputs to dist root.
+              // ../src/foo can only be written from a directory below root
+              // (top-level bin/), whose output is dist/bin/ -> one level up.
+              outPath = importerDir === "bin"
+                ? `../${entryName}${outputExtension}`
+                : `./${entryName}${outputExtension}`;
+            } else {
+              // Target bin entry outputs to dist/bin/.
+              // ../bin/foo from src/x.ts (output: root) -> ./bin/foo
+              // ../bin/foo from src/bin/x.ts (resolves to a sibling) -> ./foo
+              outPath = importerDir === "bin"
+                ? `./${entryName}${outputExtension}`
+                : `./bin/${entryName}${outputExtension}`;
+            }
             return {
-              path: `${dir}/${entryName}${outputExtension}`,
+              path: outPath,
               external: true
             };
           }

--- a/src/plugins/umd.ts
+++ b/src/plugins/umd.ts
@@ -1,5 +1,4 @@
 import * as FS from "fs/promises";
-import * as Path from "path";
 
 interface UMDPluginOptions {
   globalName: string;
@@ -12,16 +11,11 @@ export function umdPlugin(options: UMDPluginOptions) {
       build.onEnd(async (result: any) => {
         if (result.errors.length > 0) return;
 
-        // ESBuild doesn't provide outputFiles by default unless write: false
-        // We need to find the generated files in the output directory
-        const outputDir = build.initialOptions.outdir;
-        if (outputDir) {
-          const files = await FS.readdir(outputDir);
-          for (const file of files) {
-            if (file.endsWith(".js") && !file.endsWith(".js.map")) {
-              await wrapWithUMD(Path.join(outputDir, file), options.globalName);
-            }
-          }
+        // Wrap ONLY the UMD output file. Scanning the whole outdir would wrap
+        // (and corrupt) sibling ESM entry files that share the directory.
+        const outfile = build.initialOptions.outfile;
+        if (outfile) {
+          await wrapWithUMD(outfile, options.globalName);
         }
       });
     },

--- a/test/ambient-declarations.test.ts
+++ b/test/ambient-declarations.test.ts
@@ -13,7 +13,7 @@ afterEach(async () => {
   await FS.rm(testDir, {recursive: true, force: true});
 });
 
-test("copies ambient .d.ts files from src to dist/src", async () => {
+test("copies ambient .d.ts files from src to dist root", async () => {
   // Create package.json
   await FS.writeFile(
     Path.join(testDir, "package.json"),
@@ -45,8 +45,8 @@ export {};
   // Build the project
   await build(testDir, false);
 
-  // Verify ambient .d.ts was copied to dist/src
-  const distDtsPath = Path.join(testDir, "dist", "src", "global.d.ts");
+  // Verify ambient .d.ts was copied to dist root
+  const distDtsPath = Path.join(testDir, "dist", "global.d.ts");
   const distDtsExists = await FS.stat(distDtsPath).then(() => true, () => false);
   expect(distDtsExists).toBe(true);
 
@@ -86,8 +86,8 @@ test("copies multiple ambient .d.ts files", async () => {
   await build(testDir, false);
 
   // Verify both ambient .d.ts files were copied
-  const assetsDtsPath = Path.join(testDir, "dist", "src", "assets.d.ts");
-  const envDtsPath = Path.join(testDir, "dist", "src", "env.d.ts");
+  const assetsDtsPath = Path.join(testDir, "dist", "assets.d.ts");
+  const envDtsPath = Path.join(testDir, "dist", "env.d.ts");
 
   const assetsExists = await FS.stat(assetsDtsPath).then(() => true, () => false);
   const envExists = await FS.stat(envDtsPath).then(() => true, () => false);
@@ -119,7 +119,7 @@ test("works correctly when no ambient .d.ts files exist", async () => {
   await build(testDir, false);
 
   // Verify dist was created and has the generated .d.ts (not ambient)
-  const distIndexDts = Path.join(testDir, "dist", "src", "index.d.ts");
+  const distIndexDts = Path.join(testDir, "dist", "index.d.ts");
   const exists = await FS.stat(distIndexDts).then(() => true, () => false);
   expect(exists).toBe(true);
 });
@@ -214,7 +214,7 @@ declare global {
   await build(testDir, false);
 
   // Verify ambient .d.ts was copied with exact content
-  const distDtsPath = Path.join(testDir, "dist", "src", "types.d.ts");
+  const distDtsPath = Path.join(testDir, "dist", "types.d.ts");
   const copiedContent = await FS.readFile(distDtsPath, "utf-8");
   expect(copiedContent).toBe(complexAmbient);
 });
@@ -253,13 +253,13 @@ test("adds ambient .d.ts files to exports map with --save", async () => {
   const distPkg = JSON.parse(distPkgContent);
 
   // Verify exports in root package.json point to dist
-  expect(rootPkg.exports["./globals.d.ts"]).toBe("./dist/src/globals.d.ts");
+  expect(rootPkg.exports["./globals.d.ts"]).toBe("./dist/globals.d.ts");
 
-  // Verify exports in dist package.json point to src (relative to dist/)
-  expect(distPkg.exports["./globals.d.ts"]).toBe("./src/globals.d.ts");
+  // Verify exports in dist package.json point to dist root (relative to dist/)
+  expect(distPkg.exports["./globals.d.ts"]).toBe("./globals.d.ts");
 
   // Verify the file actually exists
-  const globalsDtsPath = Path.join(testDir, "dist", "src", "globals.d.ts");
+  const globalsDtsPath = Path.join(testDir, "dist", "globals.d.ts");
   const exists = await FS.stat(globalsDtsPath).then(() => true, () => false);
   expect(exists).toBe(true);
 

--- a/test/bin-directory.test.ts
+++ b/test/bin-directory.test.ts
@@ -44,15 +44,14 @@ test("bin directory detection and build", async () => {
 
   // Check that both src and bin outputs exist
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
   const distBinDir = Path.join(distDir, "bin");
 
-  // Src outputs (both ESM and CJS)
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(true);
-  
+  // Src outputs land flat at the dist root (both ESM and CJS)
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(true);
+
   // TypeScript declarations might not be available in test environment
-  const hasSrcDts = await fileExists(Path.join(distSrcDir, "index.d.ts"));
+  const hasSrcDts = await fileExists(Path.join(distDir, "index.d.ts"));
   if (hasSrcDts) {
     console.log("✓ TypeScript declarations generated for src");
   } else {
@@ -76,19 +75,19 @@ test("bin directory detection and build", async () => {
   const isExecutable = (binStat.mode & 0o111) !== 0;
   expect(isExecutable).toBe(true);
 
-  // Verify that bin entry externalizes src imports
+  // Verify that bin entry externalizes src imports (rewritten to flat dist root)
   const binContent = await FS.readFile(Path.join(distBinDir, "cli.js"), "utf-8");
-  expect(binContent).toContain('from "../src/index.js"'); // Should be external, not bundled
+  expect(binContent).toContain('from "../index.js"'); // Should be external, not bundled
   expect(binContent).not.toContain('function greet'); // Should NOT contain the actual greet function
 
   // Check package.json was generated correctly
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
-  
+
   // Should have exports for both src and bin entries
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   expect(distPkg.exports["./bin/cli"]).toEqual({
@@ -141,10 +140,10 @@ test("bin directory --save updates package.json correctly", async () => {
     tool: "./dist/bin/tool.js"
   });
 
-  // Check main/module/types fields for src entries
-  expect(rootPkg.main).toBe("./dist/src/utils.cjs");
-  expect(rootPkg.module).toBe("./dist/src/utils.js");
-  expect(rootPkg.types).toBe("./dist/src/utils.d.ts");
+  // Check main/module/types fields for src entries (flat layout)
+  expect(rootPkg.main).toBe("./dist/utils.cjs");
+  expect(rootPkg.module).toBe("./dist/utils.js");
+  expect(rootPkg.types).toBe("./dist/utils.d.ts");
 
   // Cleanup
   await removeTempDir(testDir);
@@ -204,17 +203,17 @@ test("mixed src and bin entries with exports", async () => {
   const distDir = Path.join(testDir, "dist");
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
 
-  // Should have exports for all src entries (with CJS)
+  // Should have exports for all src entries (with CJS), flat at dist root
   expect(distPkg.exports["./utils"]).toEqual({
-    types: "./src/utils.d.ts",
-    import: "./src/utils.js",
-    require: "./src/utils.cjs"
+    types: "./utils.d.ts",
+    import: "./utils.js",
+    require: "./utils.cjs"
   });
 
   expect(distPkg.exports["./api"]).toEqual({
-    types: "./src/api.d.ts", 
-    import: "./src/api.js",
-    require: "./src/api.cjs"
+    types: "./api.d.ts",
+    import: "./api.js",
+    require: "./api.cjs"
   });
 
   // Should have exports for all bin entries (ESM only)
@@ -299,8 +298,9 @@ console.log(helper());`
     "utf-8"
   );
 
-  // Entry point import should be externalized
-  expect(binContent).toContain('from "../src/index.js"');
+  // Entry point import should be externalized (rewritten to flat dist root)
+  expect(binContent).toContain('from "../index.js"');
+  expect(binContent).not.toContain('from "../src/index.js"'); // Old nested path should be gone
   expect(binContent).not.toContain('function greet'); // Should NOT be bundled
 
   // Non-entry import should be bundled
@@ -342,8 +342,10 @@ test("src file referenced in package.json bin gets dual runtime shebang", async 
 
   await build(testDir, false);
 
+  // Flat layout: the real (shebang'd) CLI output lives at dist/cli.js;
+  // dist/src/cli.js is only a re-export compatibility stub.
   const cliContent = await FS.readFile(
-    Path.join(testDir, "dist/src/cli.js"),
+    Path.join(testDir, "dist/cli.js"),
     "utf-8"
   );
 
@@ -353,7 +355,7 @@ test("src file referenced in package.json bin gets dual runtime shebang", async 
   expect(cliContent).toContain("npm_config_user_agent");
 
   // Should be executable
-  const cliStat = await FS.stat(Path.join(testDir, "dist/src/cli.js"));
+  const cliStat = await FS.stat(Path.join(testDir, "dist/cli.js"));
   expect((cliStat.mode & 0o111) !== 0).toBe(true);
 
   await removeTempDir(testDir);

--- a/test/bin-directory.test.ts
+++ b/test/bin-directory.test.ts
@@ -342,8 +342,7 @@ test("src file referenced in package.json bin gets dual runtime shebang", async 
 
   await build(testDir, false);
 
-  // Flat layout: the real (shebang'd) CLI output lives at dist/cli.js;
-  // dist/src/cli.js is only a re-export compatibility stub.
+  // Flat layout: the (shebang'd) CLI output lives at dist/cli.js
   const cliContent = await FS.readFile(
     Path.join(testDir, "dist/cli.js"),
     "utf-8"

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -17,34 +17,33 @@ test("simple library build", async () => {
   // Build
   await build(testDir);
 
-  // Check outputs exist (structure-preserving: dist/src/)
+  // Check outputs exist (flat: dist/)
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(true);
   expect(await fileExists(Path.join(distDir, "package.json"))).toBe(true);
 
   // TypeScript declarations might not be available in test environment
-  const hasDts = await fileExists(Path.join(distSrcDir, "index.d.ts"));
+  const hasDts = await fileExists(Path.join(distDir, "index.d.ts"));
   if (hasDts) {
     console.log("✓ TypeScript declarations generated");
   } else {
     console.log("⚠ TypeScript declarations not available (tsc not found)");
   }
 
-  // Check package.json structure (structure-preserving)
+  // Check package.json structure (flat output)
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
   expect(distPkg.name).toBe("simple-lib");
-  expect(distPkg.main).toBe("src/index.cjs");
-  expect(distPkg.module).toBe("src/index.js");
-  expect(distPkg.types).toBe("src/index.d.ts");
+  expect(distPkg.main).toBe("index.cjs");
+  expect(distPkg.module).toBe("index.js");
+  expect(distPkg.types).toBe("index.d.ts");
   expect(distPkg.scripts).toBeUndefined(); // Scripts should be excluded
 
-  // Check exports (structure-preserving)
+  // Check exports (flat output)
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   // Cleanup
@@ -61,26 +60,25 @@ test("multi-entry library build", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
-  // Check all entry files exist (structure-preserving)
+  // Check all entry files exist (flat output)
   const entries = ["index", "utils", "api", "cli"];
   for (const entry of entries) {
-    expect(await fileExists(Path.join(distSrcDir, `${entry}.js`))).toBe(true);
-    expect(await fileExists(Path.join(distSrcDir, `${entry}.cjs`))).toBe(true);
+    expect(await fileExists(Path.join(distDir, `${entry}.js`))).toBe(true);
+    expect(await fileExists(Path.join(distDir, `${entry}.cjs`))).toBe(true);
     // Don't require .d.ts files as tsc might not be available
   }
 
-  // Check exports for all entries (structure-preserving)
+  // Check exports for all entries (flat output)
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
   expect(distPkg.exports["./utils"]).toEqual({
-    types: "./src/utils.d.ts",
-    import: "./src/utils.js",
-    require: "./src/utils.cjs"
+    types: "./utils.d.ts",
+    import: "./utils.js",
+    require: "./utils.cjs"
   });
 
-  // Check bin transformation (structure-preserving, npm convention)
-  expect(distPkg.bin.mytool).toBe("src/cli.js"); // src/cli.js → src/cli.js (no ./ prefix)
+  // Check bin transformation (flat output, npm convention)
+  expect(distPkg.bin.mytool).toBe("cli.js"); // src/cli.js → cli.js (no ./ prefix)
 
   // Verify scripts are not copied to dist (they won't work anyway)
   expect(distPkg.scripts).toBeUndefined();
@@ -102,16 +100,16 @@ test("root package.json is updated correctly", async () => {
 
   // Check root package.json was updated (structure-preserving with --save)
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
-  expect(rootPkg.main).toBe("./dist/src/index.cjs");
-  expect(rootPkg.module).toBe("./dist/src/index.js");
-  expect(rootPkg.types).toBe("./dist/src/index.d.ts");
-  expect(rootPkg.bin.mytool).toBe("./dist/src/cli.js");
+  expect(rootPkg.main).toBe("./dist/index.cjs");
+  expect(rootPkg.module).toBe("./dist/index.js");
+  expect(rootPkg.types).toBe("./dist/index.d.ts");
+  expect(rootPkg.bin.mytool).toBe("./dist/cli.js");
 
-  // Check dist-prefixed exports (structure-preserving)
+  // Check dist-prefixed exports (flat output)
   expect(rootPkg.exports["./utils"]).toEqual({
-    types: "./dist/src/utils.d.ts",
-    import: "./dist/src/utils.js",
-    require: "./dist/src/utils.cjs"
+    types: "./dist/utils.d.ts",
+    import: "./dist/utils.js",
+    require: "./dist/utils.cjs"
   });
 
   // Cleanup
@@ -132,20 +130,19 @@ test("UMD build", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
-  // Check UMD file exists (structure-preserving)
-  expect(await fileExists(Path.join(distSrcDir, "umd.js"))).toBe(true);
+  // Check UMD file exists (flat output)
+  expect(await fileExists(Path.join(distDir, "umd.js"))).toBe(true);
 
   // Check UMD content contains wrapper
-  const umdContent = await FS.readFile(Path.join(distSrcDir, "umd.js"), "utf-8");
+  const umdContent = await FS.readFile(Path.join(distDir, "umd.js"), "utf-8");
   expect(umdContent).toContain("typeof define === 'function' && define.amd");
   expect(umdContent).toContain("root.Umdlib = factory()"); // Should use capitalized package name without hyphens
 
-  // Check package.json has UMD export (structure-preserving)
+  // Check package.json has UMD export (flat output)
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
   expect(distPkg.exports["./umd"]).toEqual({
-    require: "./src/umd.js"
+    require: "./umd.js"
   });
 
   // Cleanup
@@ -169,22 +166,21 @@ test("UMD build works with ESM-only mode", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check UMD file exists
-  expect(await fileExists(Path.join(distSrcDir, "umd.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "umd.js"))).toBe(true);
 
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
 
   // UMD export should exist
   expect(distPkg.exports["./umd"]).toEqual({
-    require: "./src/umd.js"
+    require: "./umd.js"
   });
 
   // Regular entries should be ESM-only
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js"
+    types: "./index.d.ts",
+    import: "./index.js"
     // No require condition
   });
 
@@ -213,14 +209,14 @@ test("UMD build works with dual mode", async () => {
 
   // UMD export should exist
   expect(distPkg.exports["./umd"]).toEqual({
-    require: "./src/umd.js"
+    require: "./umd.js"
   });
 
   // Regular entries should be dual format
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   // Cleanup
@@ -248,22 +244,21 @@ test("ESM-only build when no main field", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check that only ESM file exists
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(false);
 
   // Check package.json structure
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
   expect(distPkg.main).toBeUndefined(); // No main field
-  expect(distPkg.module).toBe("src/index.js");
-  expect(distPkg.types).toBe("src/index.d.ts");
+  expect(distPkg.module).toBe("index.js");
+  expect(distPkg.types).toBe("index.d.ts");
 
   // Check exports structure (ESM-only)
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js"
+    types: "./index.d.ts",
+    import: "./index.js"
     // No require condition
   });
 
@@ -288,23 +283,22 @@ test("Dual build when main field exists", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check that both ESM and CJS files exist
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(true);
 
   // Check package.json structure
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
-  expect(distPkg.main).toBe("src/index.cjs");
-  expect(distPkg.module).toBe("src/index.js");
-  expect(distPkg.types).toBe("src/index.d.ts");
+  expect(distPkg.main).toBe("index.cjs");
+  expect(distPkg.module).toBe("index.js");
+  expect(distPkg.types).toBe("index.d.ts");
 
   // Check exports structure (dual format)
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   // Cleanup
@@ -342,28 +336,28 @@ test("Export merging preserves user-defined exports", async () => {
 
   // Check that user exports are preserved and expanded
   expect(distPkg.exports["./jsx-runtime"]).toEqual({
-    types: "./src/jsx-runtime.d.ts",
-    import: "./src/jsx-runtime.js",
-    require: "./src/jsx-runtime.cjs"
+    types: "./jsx-runtime.d.ts",
+    import: "./jsx-runtime.js",
+    require: "./jsx-runtime.cjs"
   });
 
   expect(distPkg.exports["./special-alias"]).toEqual({
-    types: "./src/utils.d.ts", // Note: inferred from string path
-    import: "./src/utils.js",
-    require: "./src/utils.cjs"
+    types: "./utils.d.ts", // Note: inferred from string path
+    import: "./utils.js",
+    require: "./utils.cjs"
   });
 
   // Auto-discovered entries should be added
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   expect(distPkg.exports["./utils"]).toEqual({
-    types: "./src/utils.d.ts",
-    import: "./src/utils.js",
-    require: "./src/utils.cjs"
+    types: "./utils.d.ts",
+    import: "./utils.js",
+    require: "./utils.cjs"
   });
 
   // Cleanup
@@ -393,38 +387,37 @@ test("ESM-only export merging (no main field)", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check that only ESM files exist
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(false);
-  expect(await fileExists(Path.join(distSrcDir, "utils.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "utils.cjs"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "utils.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "utils.cjs"))).toBe(false);
 
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
 
   // Check that user exports are preserved but NOT expanded to dual format
   expect(distPkg.exports["./jsx-runtime"]).toEqual({
-    types: "./src/jsx-runtime.d.ts",
-    import: "./src/jsx-runtime.js"
+    types: "./jsx-runtime.d.ts",
+    import: "./jsx-runtime.js"
     // No require condition
   });
 
   expect(distPkg.exports["./special"]).toEqual({
-    types: "./src/utils.d.ts",
-    import: "./src/utils.js"
+    types: "./utils.d.ts",
+    import: "./utils.js"
     // No require condition
   });
 
   // Auto-discovered entries should be ESM-only
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js"
+    types: "./index.d.ts",
+    import: "./index.js"
   });
 
   expect(distPkg.exports["./utils"]).toEqual({
-    types: "./src/utils.d.ts",
-    import: "./src/utils.js"
+    types: "./utils.d.ts",
+    import: "./utils.js"
   });
 
   // Cleanup
@@ -452,33 +445,32 @@ test("Custom main entry via exports field", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check that both entries were built
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "custom.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "custom.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "custom.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "custom.cjs"))).toBe(true);
 
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
 
   // Main should point to custom entry, not index
-  expect(distPkg.main).toBe("src/custom.cjs");
-  expect(distPkg.module).toBe("src/custom.js");
-  expect(distPkg.types).toBe("src/custom.d.ts");
+  expect(distPkg.main).toBe("custom.cjs");
+  expect(distPkg.module).toBe("custom.js");
+  expect(distPkg.types).toBe("custom.d.ts");
 
   // Exports should respect the custom main
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/custom.d.ts",
-    import: "./src/custom.js",
-    require: "./src/custom.cjs"
+    types: "./custom.d.ts",
+    import: "./custom.js",
+    require: "./custom.cjs"
   });
 
   // Index should still be available as separate export
   expect(distPkg.exports["./index"]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   // Cleanup
@@ -500,15 +492,15 @@ test("custom main entry detection", async () => {
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
 
   // Should detect api as main entry (not index)
-  expect(distPkg.main).toBe("src/api.cjs");
-  expect(distPkg.module).toBe("src/api.js");
-  expect(distPkg.types).toBe("src/api.d.ts");
+  expect(distPkg.main).toBe("api.cjs");
+  expect(distPkg.module).toBe("api.js");
+  expect(distPkg.types).toBe("api.d.ts");
 
   // Main export should point to api
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/api.d.ts",
-    import: "./src/api.js",
-    require: "./src/api.cjs"
+    types: "./api.d.ts",
+    import: "./api.js",
+    require: "./api.cjs"
   });
 
   // Should still have all entry exports
@@ -594,9 +586,9 @@ test("validates that exports only reference valid entrypoints", async () => {
 
   // Should expand properly
   expect(distPkg.exports["./helper"]).toEqual({
-    types: "./src/utils.d.ts",
-    import: "./src/utils.js",
-    require: "./src/utils.cjs"
+    types: "./utils.d.ts",
+    import: "./utils.js",
+    require: "./utils.cjs"
   });
 
   // Cleanup
@@ -628,9 +620,9 @@ test("main entry detection: package.json main field", async () => {
   await build(testDir, false);
 
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
-  expect(distPkg.main).toBe("src/api.cjs");
-  expect(distPkg.module).toBe("src/api.js");
-  expect(distPkg.types).toBe("src/api.d.ts");
+  expect(distPkg.main).toBe("api.cjs");
+  expect(distPkg.module).toBe("api.js");
+  expect(distPkg.types).toBe("api.d.ts");
 
   // Cleanup
   await removeTempDir(testDir);
@@ -655,8 +647,8 @@ test("main entry detection: single entry becomes main", async () => {
   await build(testDir, false);
 
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
-  expect(distPkg.main).toBe("src/single.cjs");
-  expect(distPkg.module).toBe("src/single.js");
+  expect(distPkg.main).toBe("single.cjs");
+  expect(distPkg.module).toBe("single.js");
 
   // Cleanup
   await removeTempDir(testDir);
@@ -682,8 +674,8 @@ test("main entry detection: use package name as entry", async () => {
   await build(testDir, false);
 
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
-  expect(distPkg.main).toBe("src/mylib.cjs");
-  expect(distPkg.module).toBe("src/mylib.js");
+  expect(distPkg.main).toBe("mylib.cjs");
+  expect(distPkg.module).toBe("mylib.js");
 
   // Cleanup
   await removeTempDir(testDir);
@@ -709,7 +701,7 @@ test("main entry detection: scoped package name", async () => {
   await build(testDir, false);
 
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
-  expect(distPkg.main).toBe("src/mylib.cjs");
+  expect(distPkg.main).toBe("mylib.cjs");
 
   // Cleanup
   await removeTempDir(testDir);
@@ -760,8 +752,8 @@ test("main entry detection: default to first entry alphabetically", async () => 
 
   // Should use "api" as main (first alphabetically)
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
-  expect(distPkg.main).toBe("src/api.cjs");
-  expect(distPkg.module).toBe("src/api.js");
+  expect(distPkg.main).toBe("api.cjs");
+  expect(distPkg.module).toBe("api.js");
 
   // Cleanup
   await removeTempDir(testDir);
@@ -788,8 +780,8 @@ test("main entry detection: module field", async () => {
 
   // Should detect custom as main entry (from module field)
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
-  expect(distPkg.module).toBe("src/custom.js");
-  expect(distPkg.types).toBe("src/custom.d.ts");
+  expect(distPkg.module).toBe("custom.js");
+  expect(distPkg.types).toBe("custom.d.ts");
 
   // Cleanup
   await removeTempDir(testDir);
@@ -865,8 +857,8 @@ export function add(a: number, b: number): number {
 
   await build(testDir);
 
-  const distSrcDir = Path.join(testDir, "dist", "src");
-  const cliContent = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
+  const distDir = Path.join(testDir, "dist");
+  const cliContent = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
 
   // Should have dual runtime shebang at the very beginning
   expect(cliContent.startsWith("#\!/usr/bin/env sh")).toBe(true);
@@ -924,8 +916,8 @@ export function process() {
 
   await build(testDir);
 
-  const distSrcDir = Path.join(testDir, "dist", "src");
-  const cliContent = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
+  const distDir = Path.join(testDir, "dist");
+  const cliContent = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
 
   // Should have dual runtime shebang
   expect(cliContent.startsWith("#\!/usr/bin/env sh")).toBe(true);
@@ -939,8 +931,8 @@ export function process() {
   expect(cliContent).not.toContain('export function process');
 
   // Verify the imported files exist and contain their implementations
-  const versionContent = await FS.readFile(Path.join(distSrcDir, "version.js"), "utf-8");
-  const processContent = await FS.readFile(Path.join(distSrcDir, "process.js"), "utf-8");
+  const versionContent = await FS.readFile(Path.join(distDir, "version.js"), "utf-8");
+  const processContent = await FS.readFile(Path.join(distDir, "process.js"), "utf-8");
 
   expect(versionContent).toContain('export');
   expect(versionContent).toContain('"1.0.0"');
@@ -980,17 +972,16 @@ test("ignores common test file patterns", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check that valid entries were built
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "utils.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "utils.js"))).toBe(true);
 
   // Check that test files were NOT built
-  expect(await fileExists(Path.join(distSrcDir, "index.test.js"))).toBe(false);
-  expect(await fileExists(Path.join(distSrcDir, "utils.test.js"))).toBe(false);
-  expect(await fileExists(Path.join(distSrcDir, "component.spec.js"))).toBe(false);
-  expect(await fileExists(Path.join(distSrcDir, "api.spec.js"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "index.test.js"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "utils.test.js"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "component.spec.js"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "api.spec.js"))).toBe(false);
 
   // Check exports - should only include valid entries
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
@@ -1033,15 +1024,14 @@ test("ignores test directories", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check that valid entries were built
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "api.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "api.js"))).toBe(true);
 
   // Check that test directories were NOT copied/processed
-  expect(await fileExists(Path.join(distSrcDir, "__tests__"))).toBe(false);
-  expect(await fileExists(Path.join(distSrcDir, "test"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "__tests__"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "test"))).toBe(false);
 
   // Check exports - should only include valid entries
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
@@ -1081,10 +1071,9 @@ test("test ignoring works with mixed valid and test files", async () => {
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
   // Check that only valid entries were built (3 valid files)
-  const builtFiles = await FS.readdir(distSrcDir);
+  const builtFiles = await FS.readdir(distDir);
   const jsFiles = builtFiles.filter(f => f.endsWith('.js'));
   
   // Should have index.js, utils.js, api.js only

--- a/test/code-splitting.test.ts
+++ b/test/code-splitting.test.ts
@@ -51,13 +51,12 @@ export const version = "1.0.0";
   await build(testDir, false);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
-  // Main entry should exist
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
+  // Main entry should exist at dist root
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
 
-  // Check for chunk files in dist/src/_chunks/
-  const chunksDir = Path.join(distSrcDir, "_chunks");
+  // Check for chunk files in dist/_chunks/
+  const chunksDir = Path.join(distDir, "_chunks");
   const chunksExist = await FS.stat(chunksDir).then(() => true, () => false);
   expect(chunksExist).toBe(true);
 
@@ -67,7 +66,7 @@ export const version = "1.0.0";
   expect(chunkFiles.length).toBeGreaterThan(0);
 
   // Verify the main file contains import() for the chunk
-  const mainContent = await FS.readFile(Path.join(distSrcDir, "index.js"), "utf-8");
+  const mainContent = await FS.readFile(Path.join(distDir, "index.js"), "utf-8");
   expect(mainContent).toContain("import(");
 
   await removeTempDir(testDir);
@@ -137,9 +136,8 @@ main();
   // CLI should exist
   expect(await fileExists(Path.join(distBinDir, "cli.js"))).toBe(true);
 
-  // Check for chunk files in dist/src/_chunks/
-  const distSrcDir = Path.join(distDir, "src");
-  const chunksDir = Path.join(distSrcDir, "_chunks");
+  // Check for chunk files in dist/_chunks/
+  const chunksDir = Path.join(distDir, "_chunks");
   const chunksExist = await FS.stat(chunksDir).then(() => true, () => false);
   expect(chunksExist).toBe(true);
 
@@ -196,10 +194,9 @@ test("runtime execution with code splitting works", async () => {
   await build(testDir, false);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
-  // Verify chunk files were created in dist/src/_chunks/
-  const chunksDir = Path.join(distSrcDir, "_chunks");
+  // Verify chunk files were created in dist/_chunks/
+  const chunksDir = Path.join(distDir, "_chunks");
   const chunksExist = await FS.stat(chunksDir).then(() => true, () => false);
   expect(chunksExist).toBe(true);
 
@@ -207,7 +204,7 @@ test("runtime execution with code splitting works", async () => {
   expect(chunkFiles.length).toBeGreaterThan(0);
 
   // Test runtime execution
-  const indexPath = Path.join(distSrcDir, "index.js");
+  const indexPath = Path.join(distDir, "index.js");
   const mod = await import(indexPath);
   const result = await mod.add(2, 3);
   expect(result).toBe(5);
@@ -272,10 +269,9 @@ export async function loadFeatureC() {
   await build(testDir, false);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
-  // Check for multiple chunk files in dist/src/_chunks/
-  const chunksDir = Path.join(distSrcDir, "_chunks");
+  // Check for multiple chunk files in dist/_chunks/
+  const chunksDir = Path.join(distDir, "_chunks");
   const chunksExist = await FS.stat(chunksDir).then(() => true, () => false);
   expect(chunksExist).toBe(true);
 

--- a/test/dts-bundling.test.ts
+++ b/test/dts-bundling.test.ts
@@ -40,12 +40,12 @@ export function main() { return "main"; }`
   await build(testDir, false);
 
   // Check that impl directory exists with .d.ts
-  const implDtsPath = Path.join(testDir, "dist", "src", "impl", "utils.d.ts");
+  const implDtsPath = Path.join(testDir, "dist", "impl", "utils.d.ts");
   const implDtsExists = await FS.stat(implDtsPath).then(() => true, () => false);
   expect(implDtsExists).toBe(true);
 
   // Check index.d.ts references impl
-  const indexDts = await FS.readFile(Path.join(testDir, "dist", "src", "index.d.ts"), "utf-8");
+  const indexDts = await FS.readFile(Path.join(testDir, "dist", "index.d.ts"), "utf-8");
   expect(indexDts).toContain("./impl/utils.js");
 });
 
@@ -86,7 +86,7 @@ declare module "some-external-lib" {
 
   // Check that augmentation is in the generated .d.ts
   const augmentDts = await FS.readFile(
-    Path.join(testDir, "dist", "src", "impl", "augment.d.ts"),
+    Path.join(testDir, "dist", "impl", "augment.d.ts"),
     "utf-8"
   );
   expect(augmentDts).toContain('declare module "some-external-lib"');
@@ -131,10 +131,10 @@ export function levelB() { return "b"; }`
 
   // Check all .d.ts files exist
   const paths = [
-    "dist/src/index.d.ts",
-    "dist/src/a/level-a.d.ts",
-    "dist/src/a/b/level-b.d.ts",
-    "dist/src/a/b/c/level-c.d.ts",
+    "dist/index.d.ts",
+    "dist/a/level-a.d.ts",
+    "dist/a/b/level-b.d.ts",
+    "dist/a/b/c/level-c.d.ts",
   ];
 
   for (const p of paths) {
@@ -180,9 +180,9 @@ export function utils() { return "utils"; }`
   await build(testDir, false);
 
   // Check both entries and shared module have .d.ts
-  const indexDts = await FS.readFile(Path.join(testDir, "dist", "src", "index.d.ts"), "utf-8");
-  const utilsDts = await FS.readFile(Path.join(testDir, "dist", "src", "utils.d.ts"), "utf-8");
-  const sharedDts = await FS.readFile(Path.join(testDir, "dist", "src", "shared", "common.d.ts"), "utf-8");
+  const indexDts = await FS.readFile(Path.join(testDir, "dist", "index.d.ts"), "utf-8");
+  const utilsDts = await FS.readFile(Path.join(testDir, "dist", "utils.d.ts"), "utf-8");
+  const sharedDts = await FS.readFile(Path.join(testDir, "dist", "shared", "common.d.ts"), "utf-8");
 
   expect(indexDts).toContain("./shared/common.js");
   expect(utilsDts).toContain("./shared/common.js");
@@ -224,7 +224,7 @@ declare global {
   await build(testDir, false);
 
   const globalsDts = await FS.readFile(
-    Path.join(testDir, "dist", "src", "impl", "globals.d.ts"),
+    Path.join(testDir, "dist", "impl", "globals.d.ts"),
     "utf-8"
   );
   expect(globalsDts).toContain("declare global");

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -496,3 +496,33 @@ test("root package.json path mapping with --save", async () => {
 
   await removeTempDir(testDir);
 });
+
+test("'.' export gets import field even when author declared types-only (#7)", async () => {
+  const testDir = await createTempDir("dot-import-field");
+
+  await FS.mkdir(Path.join(testDir, "src"), {recursive: true});
+  await FS.writeFile(Path.join(testDir, "src", "crank-editable.ts"), "export function editable() { return 1; }");
+  await FS.writeFile(Path.join(testDir, "package.json"), JSON.stringify({
+    name: "crank-editable",
+    version: "0.1.0",
+    type: "module",
+    module: "./dist/crank-editable.js",
+    private: true,
+    // types-only "." export - previously passed through without import,
+    // breaking bundler resolution of symlinked packages
+    exports: {
+      ".": {types: "./dist/crank-editable.d.ts"}
+    }
+  }, null, 2));
+
+  await build(testDir, true); // --save
+
+  const rootPkg = await readJSON(Path.join(testDir, "package.json"));
+  expect(rootPkg.exports["."].import).toBe("./dist/crank-editable.js");
+  expect(rootPkg.exports["."].types).toBe("./dist/crank-editable.d.ts");
+
+  const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
+  expect(distPkg.exports["."].import).toBe("./crank-editable.js");
+
+  await removeTempDir(testDir);
+});

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -23,22 +23,22 @@ test("exports field generation for multi-entry library", async () => {
 
   // Should have main export
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   // Should have individual entry exports
   expect(distPkg.exports["./api"]).toEqual({
-    types: "./src/api.d.ts",
-    import: "./src/api.js",
-    require: "./src/api.cjs"
+    types: "./api.d.ts",
+    import: "./api.js",
+    require: "./api.cjs"
   });
 
   expect(distPkg.exports["./utils"]).toEqual({
-    types: "./src/utils.d.ts",
-    import: "./src/utils.js",
-    require: "./src/utils.cjs"
+    types: "./utils.d.ts",
+    import: "./utils.js",
+    require: "./utils.cjs"
   });
 
   // Should have .js extension variants
@@ -67,24 +67,24 @@ test("exports field generation with --save mode", async () => {
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
 
   expect(rootPkg.exports["."]).toEqual({
-    types: "./dist/src/index.d.ts",
-    import: "./dist/src/index.js",
-    require: "./dist/src/index.cjs"
+    types: "./dist/index.d.ts",
+    import: "./dist/index.js",
+    require: "./dist/index.cjs"
   });
 
   expect(rootPkg.exports["./api"]).toEqual({
-    types: "./dist/src/api.d.ts",
-    import: "./dist/src/api.js",
-    require: "./dist/src/api.cjs"
+    types: "./dist/api.d.ts",
+    import: "./dist/api.js",
+    require: "./dist/api.cjs"
   });
 
   // Check dist package.json exports (should be relative)
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
 
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   // Cleanup
@@ -415,18 +415,16 @@ test("path mapping fixes for dist package.json exports", async () => {
   const distDir = Path.join(testDir, "dist");
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
 
-  // All exports should use ./src/ paths, not ./dist/src/
+  // All exports should use flat dist-root paths, never ./dist/ or ./src/ prefixes
   for (const [key, value] of Object.entries(distPkg.exports)) {
     if (typeof value === "string") {
-      if (value.includes("/src/")) {
-        expect(value).toMatch(/^\.\/src\//);
-        expect(value).not.toContain("./dist/src/");
-      }
+      expect(value).not.toContain("./dist/");
+      expect(value).not.toContain("./src/");
     } else if (typeof value === "object" && value !== null) {
       for (const [subKey, subValue] of Object.entries(value)) {
-        if (typeof subValue === "string" && subValue.includes("/src/")) {
-          expect(subValue).toMatch(/^\.\/src\//);
-          expect(subValue).not.toContain("./dist/src/");
+        if (typeof subValue === "string") {
+          expect(subValue).not.toContain("./dist/");
+          expect(subValue).not.toContain("./src/");
         }
       }
     }
@@ -434,15 +432,15 @@ test("path mapping fixes for dist package.json exports", async () => {
 
   // Specific exports should be correct
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
 
   expect(distPkg.exports["./cli"]).toEqual({
-    types: "./src/cli.d.ts",
-    import: "./src/cli.js",
-    require: "./src/cli.cjs"
+    types: "./cli.d.ts",
+    import: "./cli.js",
+    require: "./cli.cjs"
   });
 
   await removeTempDir(testDir);
@@ -461,13 +459,13 @@ test("no path mapping regressions in dist package.json", async () => {
   expect(jsonString).not.toContain("./dist/src/");
   expect(jsonString).not.toContain("dist/src/");
 
-  // But should contain proper ./src/ paths
-  expect(jsonString).toContain("./src/");
+  // Flat layout: no ./src/ paths in dist package.json either
+  expect(jsonString).not.toContain("./src/");
 
   // Verify specific problematic patterns are fixed
-  expect(distPkg.main).toBe("src/index.cjs");
-  expect(distPkg.module).toBe("src/index.js");
-  expect(distPkg.types).toBe("src/index.d.ts");
+  expect(distPkg.main).toBe("index.cjs");
+  expect(distPkg.module).toBe("index.js");
+  expect(distPkg.types).toBe("index.d.ts");
 
   await removeTempDir(testDir);
 });
@@ -481,16 +479,16 @@ test("root package.json path mapping with --save", async () => {
   // Check root package.json has proper dist paths
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
 
-  // Main fields should point to dist
-  expect(rootPkg.main).toBe("./dist/src/index.cjs");
-  expect(rootPkg.module).toBe("./dist/src/index.js");
-  expect(rootPkg.types).toBe("./dist/src/index.d.ts");
+  // Main fields should point to dist (flat layout)
+  expect(rootPkg.main).toBe("./dist/index.cjs");
+  expect(rootPkg.module).toBe("./dist/index.js");
+  expect(rootPkg.types).toBe("./dist/index.d.ts");
 
   // Exports should point to dist
   expect(rootPkg.exports["."]).toEqual({
-    types: "./dist/src/index.d.ts",
-    import: "./dist/src/index.js",
-    require: "./dist/src/index.cjs"
+    types: "./dist/index.d.ts",
+    import: "./dist/index.js",
+    require: "./dist/index.cjs"
   });
 
   // Should be marked as private

--- a/test/fixtures/flat-augmentation/package.json
+++ b/test/fixtures/flat-augmentation/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "flat-augmentation",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "private": true
+}

--- a/test/fixtures/flat-augmentation/src/impl/table.ts
+++ b/test/fixtures/flat-augmentation/src/impl/table.ts
@@ -1,0 +1,16 @@
+// Internal module (not an entry point) with a module augmentation.
+// Regression surface from issue #1: the generated .d.ts for the entry imports
+// this module by relative path, and the augmentation must survive publishing.
+export interface Table {
+  rows: number;
+}
+
+export function table(rows: number): Table {
+  return {rows};
+}
+
+declare module "node:events" {
+  interface EventEmitter {
+    tableCount?: number;
+  }
+}

--- a/test/fixtures/flat-augmentation/src/index.ts
+++ b/test/fixtures/flat-augmentation/src/index.ts
@@ -1,0 +1,6 @@
+export {table} from "./impl/table.js";
+export type {Table} from "./impl/table.js";
+
+export default function createTable(rows: number) {
+  return {rows};
+}

--- a/test/flat-output.test.ts
+++ b/test/flat-output.test.ts
@@ -151,3 +151,49 @@ test("flat layout: npm pack ships root modules, no src/ paths", async () => {
 
   await removeTempDir(testDir);
 });
+
+test(".tsx entry points are discovered and built (#6)", async () => {
+  const testDir = await createTempDir("tsx-entry");
+
+  await FS.mkdir(Path.join(testDir, "src"), {recursive: true});
+  await FS.writeFile(Path.join(testDir, "package.json"), JSON.stringify({
+    name: "tsx-lib",
+    version: "1.0.0",
+    type: "module",
+    module: "./dist/index.js",
+    private: true
+  }, null, 2));
+  // hermetic JSX via pragma - no external jsx runtime needed
+  await FS.writeFile(Path.join(testDir, "src", "h.ts"),
+    "export function h(tag: any, props: any, ...children: any[]) { return {tag, props, children}; }");
+  await FS.writeFile(Path.join(testDir, "src", "widget.tsx"),
+    '/** @jsx h */\nimport {h} from "./h.js";\nexport function widget(name: string) { return <div title={name}>hi</div>; }');
+  await FS.writeFile(Path.join(testDir, "src", "index.ts"),
+    'export {widget} from "./widget.js";');
+
+  await build(testDir);
+
+  const distDir = Path.join(testDir, "dist");
+
+  // .tsx entry built to root as .js
+  expect(await fileExists(Path.join(distDir, "widget.js"))).toBe(true);
+  const js = await FS.readFile(Path.join(distDir, "widget.js"), "utf-8");
+  expect(js).not.toContain("<div"); // JSX compiled away
+
+  // runtime works
+  const mod = await import(Path.join(distDir, "widget.js"));
+  const node = mod.widget("x");
+  expect(node.tag).toBe("div");
+  expect(node.props.title).toBe("x");
+
+  // exports map includes the tsx entry
+  const distPkg = await readJSON(Path.join(distDir, "package.json"));
+  expect(distPkg.exports["./widget"].import).toBe("./widget.js");
+
+  // declarations (if tsc available)
+  if (await fileExists(Path.join(distDir, "index.d.ts"))) {
+    expect(await fileExists(Path.join(distDir, "widget.d.ts"))).toBe(true);
+  }
+
+  await removeTempDir(testDir);
+});

--- a/test/flat-output.test.ts
+++ b/test/flat-output.test.ts
@@ -1,0 +1,205 @@
+import {test, expect} from "bun:test";
+import * as FS from "fs/promises";
+import * as Path from "path";
+import {createRequire} from "module";
+import {build} from "../src/libuild.ts";
+import {createTempDir, removeTempDir, copyFixture, readJSON, fileExists} from "./test-utils.ts";
+
+// =============================================================================
+// FLAT OUTPUT LAYOUT (#9)
+//
+// Modules publish at the tarball root (dist/<entry>.js) instead of dist/src/.
+// dist/src/ holds compatibility stubs so previously published src/-relative
+// paths (CDN literal URLs, deep imports bypassing the exports map) resolve.
+// =============================================================================
+
+test("flat layout: modules at root, stubs under src/", async () => {
+  const testDir = await createTempDir("flat-layout");
+  await copyFixture("multi-entry", testDir);
+
+  await build(testDir);
+
+  const distDir = Path.join(testDir, "dist");
+
+  // Real modules at the dist root
+  for (const entry of ["index", "utils", "api", "cli"]) {
+    expect(await fileExists(Path.join(distDir, `${entry}.js`))).toBe(true);
+    expect(await fileExists(Path.join(distDir, `${entry}.cjs`))).toBe(true);
+  }
+
+  // Compatibility stubs at the old src/ locations
+  const stubJs = await FS.readFile(Path.join(distDir, "src", "utils.js"), "utf-8");
+  expect(stubJs).toContain('export * from "../utils.js"');
+  const stubCjs = await FS.readFile(Path.join(distDir, "src", "utils.cjs"), "utf-8");
+  expect(stubCjs).toContain('module.exports = require("../utils.cjs")');
+
+  // Stubs are stubs, not copies - real code stays at the root only
+  const realJs = await FS.readFile(Path.join(distDir, "utils.js"), "utf-8");
+  expect(realJs).toContain("function add");
+  expect(stubJs).not.toContain("function add");
+
+  // Package.json points at the root (canonical) paths
+  const distPkg = await readJSON(Path.join(distDir, "package.json"));
+  expect(distPkg.module).toBe("index.js");
+  expect(distPkg.exports["."].import).toBe("./index.js");
+  expect(distPkg.exports["./utils"].import).toBe("./utils.js");
+
+  await removeTempDir(testDir);
+});
+
+test("flat layout: stubs resolve at runtime (old deep-path consumers)", async () => {
+  const testDir = await createTempDir("flat-stub-runtime");
+  await copyFixture("multi-entry", testDir);
+
+  await build(testDir);
+
+  const distDir = Path.join(testDir, "dist");
+
+  // ESM stub forwards named exports (simulates a CDN literal /src/ URL or a
+  // bundler resolving the literal file path)
+  const esmStub = await import(Path.join(distDir, "src", "utils.js"));
+  expect(esmStub.add(2, 3)).toBe(5);
+
+  // CJS stub forwards module.exports
+  const require = createRequire(import.meta.url);
+  const cjsStub = require(Path.join(distDir, "src", "utils.cjs"));
+  expect(cjsStub.add(4, 5)).toBe(9);
+
+  await removeTempDir(testDir);
+});
+
+test("flat layout: stubs forward default exports (metafile-driven)", async () => {
+  const testDir = await createTempDir("flat-stub-default");
+  await copyFixture("flat-augmentation", testDir);
+
+  await build(testDir);
+
+  const distDir = Path.join(testDir, "dist");
+
+  // index has a default export - the stub must re-export it explicitly
+  // (export * does not forward default)
+  const stub = await FS.readFile(Path.join(distDir, "src", "index.js"), "utf-8");
+  expect(stub).toContain('export * from "../index.js"');
+  expect(stub).toContain('export {default} from "../index.js"');
+
+  const viaStub = await import(Path.join(distDir, "src", "index.js"));
+  expect(viaStub.default(3).rows).toBe(3);
+  expect(viaStub.table(7).rows).toBe(7);
+
+  // A module without a default export must NOT get the default re-export
+  // (it would be a link error)
+  const utilsDir = await createTempDir("flat-stub-no-default");
+  await copyFixture("multi-entry", utilsDir);
+  await build(utilsDir);
+  const noDefaultStub = await FS.readFile(Path.join(utilsDir, "dist", "src", "utils.js"), "utf-8");
+  expect(noDefaultStub).not.toContain("export {default}");
+
+  await removeTempDir(testDir);
+  await removeTempDir(utilsDir);
+});
+
+test("flat layout: internal-module .d.ts and augmentations relocate together (#1 guard)", async () => {
+  const testDir = await createTempDir("flat-augmentation");
+  await copyFixture("flat-augmentation", testDir);
+
+  await build(testDir);
+
+  const distDir = Path.join(testDir, "dist");
+
+  // TypeScript may be unavailable in some environments - skip like other tests do
+  if (!await fileExists(Path.join(distDir, "index.d.ts"))) {
+    console.log("⚠ TypeScript declarations not available (tsc not found)");
+    await removeTempDir(testDir);
+    return;
+  }
+
+  // The whole tree relocated together: entry .d.ts at root still imports the
+  // internal module by the SAME relative path, and that module's .d.ts exists
+  const indexDts = await FS.readFile(Path.join(distDir, "index.d.ts"), "utf-8");
+  expect(indexDts).toContain('"./impl/table.js"');
+  expect(await fileExists(Path.join(distDir, "impl", "table.d.ts"))).toBe(true);
+
+  // The module augmentation survives in the published declarations
+  const tableDts = await FS.readFile(Path.join(distDir, "impl", "table.d.ts"), "utf-8");
+  expect(tableDts).toContain('declare module "node:events"');
+
+  // The d.ts stub re-exports the real declarations (augmentation applies
+  // transitively for consumers who resolve the old src/ path)
+  const dtsStub = await FS.readFile(Path.join(distDir, "src", "index.d.ts"), "utf-8");
+  expect(dtsStub).toContain('export * from "../index.js"');
+
+  await removeTempDir(testDir);
+});
+
+test("flat layout: UMD builds to root, compat copy under src/, siblings not wrapped", async () => {
+  const testDir = await createTempDir("flat-umd");
+  await copyFixture("with-umd", testDir);
+
+  await build(testDir);
+
+  const distDir = Path.join(testDir, "dist");
+
+  // UMD at the root, wrapped
+  const umd = await FS.readFile(Path.join(distDir, "umd.js"), "utf-8");
+  expect(umd).toContain("typeof define === 'function' && define.amd");
+
+  // Compat copy is a real UMD file (script tags can't follow ESM stubs)
+  const umdCompat = await FS.readFile(Path.join(distDir, "src", "umd.js"), "utf-8");
+  expect(umdCompat).toContain("typeof define === 'function' && define.amd");
+
+  // Regression: the UMD pass must not wrap sibling entry files
+  // (on main, every .js in the UMD outdir was wrapped and corrupted)
+  const index = await FS.readFile(Path.join(distDir, "index.js"), "utf-8");
+  expect(index).not.toContain("define.amd");
+  expect(index).toContain("export");
+
+  await removeTempDir(testDir);
+});
+
+test("flat layout: --save root bin points at the real executable, not the stub", async () => {
+  const testDir = await createTempDir("flat-save-bin");
+  await copyFixture("multi-entry", testDir);
+
+  await build(testDir, true); // --save
+
+  // Author bin was "src/cli.js"; the flat dist location is dist/cli.js.
+  // dist/src/cli.js also EXISTS (compat stub) - the root bin must not point
+  // there, since the stub has no shebang and isn't executable.
+  const rootPkg = await readJSON(Path.join(testDir, "package.json"));
+  expect(rootPkg.bin.mytool).toBe("./dist/cli.js");
+
+  const real = await FS.readFile(Path.join(testDir, "dist", "cli.js"), "utf-8");
+  expect(real.startsWith("#!")).toBe(true);
+
+  await removeTempDir(testDir);
+});
+
+test("flat layout: npm pack ships root modules and src/ stubs", async () => {
+  const testDir = await createTempDir("flat-pack");
+  await copyFixture("multi-entry", testDir);
+
+  await build(testDir);
+
+  const distDir = Path.join(testDir, "dist");
+
+  // multi-entry fixture has private: true; npm pack --dry-run still refuses,
+  // so drop it for the pack check (publish protection is tested elsewhere)
+  const distPkg = await readJSON(Path.join(distDir, "package.json"));
+  delete distPkg.private;
+  await FS.writeFile(Path.join(distDir, "package.json"), JSON.stringify(distPkg, null, 2));
+
+  const proc = Bun.spawn(["npm", "pack", "--dry-run", "--json"], {cwd: distDir, stdout: "pipe", stderr: "pipe"});
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  const packed = JSON.parse(out)[0].files.map((f: any) => f.path);
+
+  // Canonical modules at the tarball root (clean CDN URLs: <pkg>/index.js)
+  expect(packed).toContain("index.js");
+  expect(packed).toContain("utils.js");
+  expect(packed).toContain("package.json");
+  // Compatibility stubs shipped too (old CDN URLs: <pkg>/src/index.js)
+  expect(packed).toContain("src/index.js");
+  expect(packed).toContain("src/utils.cjs");
+
+  await removeTempDir(testDir);
+});

--- a/test/flat-output.test.ts
+++ b/test/flat-output.test.ts
@@ -1,7 +1,6 @@
 import {test, expect} from "bun:test";
 import * as FS from "fs/promises";
 import * as Path from "path";
-import {createRequire} from "module";
 import {build} from "../src/libuild.ts";
 import {createTempDir, removeTempDir, copyFixture, readJSON, fileExists} from "./test-utils.ts";
 
@@ -9,11 +8,11 @@ import {createTempDir, removeTempDir, copyFixture, readJSON, fileExists} from ".
 // FLAT OUTPUT LAYOUT (#9)
 //
 // Modules publish at the tarball root (dist/<entry>.js) instead of dist/src/.
-// dist/src/ holds compatibility stubs so previously published src/-relative
-// paths (CDN literal URLs, deep imports bypassing the exports map) resolve.
+// Clean break: no src/ directory ships at all - direct CDN URLs use the root
+// paths (<pkg>/index.js), and the old <pkg>/src/ paths 404 after republish.
 // =============================================================================
 
-test("flat layout: modules at root, stubs under src/", async () => {
+test("flat layout: modules at root, no src/ directory in output", async () => {
   const testDir = await createTempDir("flat-layout");
   await copyFixture("multi-entry", testDir);
 
@@ -27,18 +26,13 @@ test("flat layout: modules at root, stubs under src/", async () => {
     expect(await fileExists(Path.join(distDir, `${entry}.cjs`))).toBe(true);
   }
 
-  // Compatibility stubs at the old src/ locations
-  const stubJs = await FS.readFile(Path.join(distDir, "src", "utils.js"), "utf-8");
-  expect(stubJs).toContain('export * from "../utils.js"');
-  const stubCjs = await FS.readFile(Path.join(distDir, "src", "utils.cjs"), "utf-8");
-  expect(stubCjs).toContain('module.exports = require("../utils.cjs")');
+  // The src/ wrapper is gone entirely
+  expect(await fileExists(Path.join(distDir, "src"))).toBe(false);
 
-  // Stubs are stubs, not copies - real code stays at the root only
   const realJs = await FS.readFile(Path.join(distDir, "utils.js"), "utf-8");
   expect(realJs).toContain("function add");
-  expect(stubJs).not.toContain("function add");
 
-  // Package.json points at the root (canonical) paths
+  // Package.json points at the root paths
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
   expect(distPkg.module).toBe("index.js");
   expect(distPkg.exports["."].import).toBe("./index.js");
@@ -47,55 +41,20 @@ test("flat layout: modules at root, stubs under src/", async () => {
   await removeTempDir(testDir);
 });
 
-test("flat layout: stubs resolve at runtime (old deep-path consumers)", async () => {
-  const testDir = await createTempDir("flat-stub-runtime");
+test("flat layout: root modules resolve at runtime (CDN-literal simulation)", async () => {
+  const testDir = await createTempDir("flat-runtime");
   await copyFixture("multi-entry", testDir);
 
   await build(testDir);
 
   const distDir = Path.join(testDir, "dist");
 
-  // ESM stub forwards named exports (simulates a CDN literal /src/ URL or a
-  // bundler resolving the literal file path)
-  const esmStub = await import(Path.join(distDir, "src", "utils.js"));
-  expect(esmStub.add(2, 3)).toBe(5);
-
-  // CJS stub forwards module.exports
-  const require = createRequire(import.meta.url);
-  const cjsStub = require(Path.join(distDir, "src", "utils.cjs"));
-  expect(cjsStub.add(4, 5)).toBe(9);
+  // A literal file lookup at the root - what jsDelivr/unpkg do for
+  // <pkg>/utils.js - resolves and works
+  const esm = await import(Path.join(distDir, "utils.js"));
+  expect(esm.add(2, 3)).toBe(5);
 
   await removeTempDir(testDir);
-});
-
-test("flat layout: stubs forward default exports (metafile-driven)", async () => {
-  const testDir = await createTempDir("flat-stub-default");
-  await copyFixture("flat-augmentation", testDir);
-
-  await build(testDir);
-
-  const distDir = Path.join(testDir, "dist");
-
-  // index has a default export - the stub must re-export it explicitly
-  // (export * does not forward default)
-  const stub = await FS.readFile(Path.join(distDir, "src", "index.js"), "utf-8");
-  expect(stub).toContain('export * from "../index.js"');
-  expect(stub).toContain('export {default} from "../index.js"');
-
-  const viaStub = await import(Path.join(distDir, "src", "index.js"));
-  expect(viaStub.default(3).rows).toBe(3);
-  expect(viaStub.table(7).rows).toBe(7);
-
-  // A module without a default export must NOT get the default re-export
-  // (it would be a link error)
-  const utilsDir = await createTempDir("flat-stub-no-default");
-  await copyFixture("multi-entry", utilsDir);
-  await build(utilsDir);
-  const noDefaultStub = await FS.readFile(Path.join(utilsDir, "dist", "src", "utils.js"), "utf-8");
-  expect(noDefaultStub).not.toContain("export {default}");
-
-  await removeTempDir(testDir);
-  await removeTempDir(utilsDir);
 });
 
 test("flat layout: internal-module .d.ts and augmentations relocate together (#1 guard)", async () => {
@@ -123,15 +82,10 @@ test("flat layout: internal-module .d.ts and augmentations relocate together (#1
   const tableDts = await FS.readFile(Path.join(distDir, "impl", "table.d.ts"), "utf-8");
   expect(tableDts).toContain('declare module "node:events"');
 
-  // The d.ts stub re-exports the real declarations (augmentation applies
-  // transitively for consumers who resolve the old src/ path)
-  const dtsStub = await FS.readFile(Path.join(distDir, "src", "index.d.ts"), "utf-8");
-  expect(dtsStub).toContain('export * from "../index.js"');
-
   await removeTempDir(testDir);
 });
 
-test("flat layout: UMD builds to root, compat copy under src/, siblings not wrapped", async () => {
+test("flat layout: UMD builds to root, siblings not wrapped", async () => {
   const testDir = await createTempDir("flat-umd");
   await copyFixture("with-umd", testDir);
 
@@ -143,10 +97,6 @@ test("flat layout: UMD builds to root, compat copy under src/, siblings not wrap
   const umd = await FS.readFile(Path.join(distDir, "umd.js"), "utf-8");
   expect(umd).toContain("typeof define === 'function' && define.amd");
 
-  // Compat copy is a real UMD file (script tags can't follow ESM stubs)
-  const umdCompat = await FS.readFile(Path.join(distDir, "src", "umd.js"), "utf-8");
-  expect(umdCompat).toContain("typeof define === 'function' && define.amd");
-
   // Regression: the UMD pass must not wrap sibling entry files
   // (on main, every .js in the UMD outdir was wrapped and corrupted)
   const index = await FS.readFile(Path.join(distDir, "index.js"), "utf-8");
@@ -156,15 +106,14 @@ test("flat layout: UMD builds to root, compat copy under src/, siblings not wrap
   await removeTempDir(testDir);
 });
 
-test("flat layout: --save root bin points at the real executable, not the stub", async () => {
+test("flat layout: --save root bin points at the flat executable", async () => {
   const testDir = await createTempDir("flat-save-bin");
   await copyFixture("multi-entry", testDir);
 
   await build(testDir, true); // --save
 
   // Author bin was "src/cli.js"; the flat dist location is dist/cli.js.
-  // dist/src/cli.js also EXISTS (compat stub) - the root bin must not point
-  // there, since the stub has no shebang and isn't executable.
+  // The saved path must be flattened - dist/src/cli.js no longer exists.
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
   expect(rootPkg.bin.mytool).toBe("./dist/cli.js");
 
@@ -174,7 +123,7 @@ test("flat layout: --save root bin points at the real executable, not the stub",
   await removeTempDir(testDir);
 });
 
-test("flat layout: npm pack ships root modules and src/ stubs", async () => {
+test("flat layout: npm pack ships root modules, no src/ paths", async () => {
   const testDir = await createTempDir("flat-pack");
   await copyFixture("multi-entry", testDir);
 
@@ -197,9 +146,8 @@ test("flat layout: npm pack ships root modules and src/ stubs", async () => {
   expect(packed).toContain("index.js");
   expect(packed).toContain("utils.js");
   expect(packed).toContain("package.json");
-  // Compatibility stubs shipped too (old CDN URLs: <pkg>/src/index.js)
-  expect(packed).toContain("src/index.js");
-  expect(packed).toContain("src/utils.cjs");
+  // Clean break: nothing ships under src/
+  expect(packed.some((p: string) => p.startsWith("src/"))).toBe(false);
 
   await removeTempDir(testDir);
 });

--- a/test/package-transforms.test.ts
+++ b/test/package-transforms.test.ts
@@ -111,7 +111,6 @@ test("handles comprehensive package.json fields", async () => {
     "*.js",
     "*.cjs",
     "*.d.ts",
-    "src/",
     "bin/",
     "_chunks/"
   ]);
@@ -405,7 +404,7 @@ test("complex bin field transformations", async () => {
   // Check root package.json bin transformations
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
   expect(rootPkg.bin).toEqual({
-    mytool: "./dist/cli.js" // flattened to the real executable, not the dist/src/ stub
+    mytool: "./dist/cli.js" // flattened to the flat-layout executable
     // processor is removed because src/tools/processor.ts is not detected as an entry
   });
   
@@ -433,7 +432,6 @@ test("files field src transformations", async () => {
     "*.js",
     "*.cjs",
     "*.d.ts",
-    "src/",
     "bin/",
     "_chunks/"
   ]);
@@ -848,7 +846,7 @@ test("bin paths work in --save mode with string format", async () => {
   
   // Check root package.json
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
-  expect(rootPkg.bin).toBe("./dist/cli.js"); // flattened to the real executable, not the dist/src/ stub
+  expect(rootPkg.bin).toBe("./dist/cli.js"); // flattened to the flat-layout executable
 
   // Check dist package.json
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));

--- a/test/package-transforms.test.ts
+++ b/test/package-transforms.test.ts
@@ -103,8 +103,18 @@ test("handles comprehensive package.json fields", async () => {
   expect(distPkg.sideEffects).toBe(false);
   expect(distPkg.browserslist).toEqual(["> 1%", "last 2 versions"]);
   
-  // Check files field transformation
-  expect(distPkg.files).toEqual(["./src/**/*", "docs/*.md"]);
+  // Check files field transformation: author extras are transformed and the
+  // flat-layout entries are appended (deduped)
+  expect(distPkg.files).toEqual([
+    "./src/**/*",
+    "docs/*.md",
+    "*.js",
+    "*.cjs",
+    "*.d.ts",
+    "src/",
+    "bin/",
+    "_chunks/"
+  ]);
   
   // Check that scripts are excluded
   expect(distPkg.scripts).toBeUndefined();
@@ -253,16 +263,16 @@ test("build with --save updates all package.json fields correctly", async () => 
   
   // Check root package.json transformations
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
-  expect(rootPkg.main).toBe("./dist/src/index.cjs");
-  expect(rootPkg.module).toBe("./dist/src/index.js");
-  expect(rootPkg.types).toBe("./dist/src/index.d.ts");
-  
+  expect(rootPkg.main).toBe("./dist/index.cjs");
+  expect(rootPkg.module).toBe("./dist/index.js");
+  expect(rootPkg.types).toBe("./dist/index.d.ts");
+
   // Check exports field is generated
   expect(rootPkg.exports).toBeDefined();
   expect(rootPkg.exports["."]).toEqual({
-    types: "./dist/src/index.d.ts",
-    import: "./dist/src/index.js",
-    require: "./dist/src/index.cjs"
+    types: "./dist/index.d.ts",
+    import: "./dist/index.js",
+    require: "./dist/index.cjs"
   });
   
   // Should not create files field if it didn't exist originally
@@ -296,9 +306,9 @@ test("adding new entry point updates exports in subsequent --save builds", async
   // Check that new entry point is in exports
   rootPkg = await readJSON(Path.join(testDir, "package.json"));
   expect(rootPkg.exports["./utils"]).toEqual({
-    types: "./dist/src/utils.d.ts",
-    import: "./dist/src/utils.js", 
-    require: "./dist/src/utils.cjs"
+    types: "./dist/utils.d.ts",
+    import: "./dist/utils.js",
+    require: "./dist/utils.cjs"
   });
   expect(rootPkg.exports["./utils.js"]).toBeDefined();
   
@@ -380,23 +390,22 @@ test("complex bin field transformations", async () => {
   
   const distDir = Path.join(testDir, "dist");
   
-  // Check that all bin entries are built (structure-preserving)
+  // Check that all bin entries are built (flat layout: dist root)
   // Since there's no main field, only ESM should be generated
-  const distSrcDir = Path.join(distDir, "src");
-  expect(await fileExists(Path.join(distSrcDir, "cli.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "cli.cjs"))).toBe(false);
-  
+  expect(await fileExists(Path.join(distDir, "cli.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "cli.cjs"))).toBe(false);
+
   // Check dist package.json bin transformations
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
   expect(distPkg.bin).toEqual({
-    mytool: "src/cli.js",              // src/cli.js → src/cli.js (npm convention)
-    processor: "src/tools/processor.js" // preserved but will warn about subdirectory
+    mytool: "cli.js",                // src/cli.js → cli.js (flat layout, npm convention)
+    processor: "tools/processor.js"  // preserved but will warn about subdirectory
   });
-  
+
   // Check root package.json bin transformations
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
   expect(rootPkg.bin).toEqual({
-    mytool: "./dist/src/cli.js"
+    mytool: "./dist/cli.js" // flattened to the real executable, not the dist/src/ stub
     // processor is removed because src/tools/processor.ts is not detected as an entry
   });
   
@@ -415,11 +424,18 @@ test("files field src transformations", async () => {
   
   const distDir = Path.join(testDir, "dist");
   
-  // Check dist package.json files transformations (structure-preserving)
+  // Check dist package.json files transformations: author extras transformed,
+  // flat-layout entries appended (deduped)
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
   expect(distPkg.files).toEqual([
     "./src/**/*",    // src/**/* → ./src/**/*
-    "docs/*.md"      // docs/*.md stays the same
+    "docs/*.md",     // docs/*.md stays the same
+    "*.js",
+    "*.cjs",
+    "*.d.ts",
+    "src/",
+    "bin/",
+    "_chunks/"
   ]);
   
   // Check that docs files were actually copied
@@ -545,9 +561,9 @@ test("bin field with string value (not object)", async () => {
   
   const distDir = Path.join(testDir, "dist");
   
-  // Check dist package.json bin transformation (structure-preserving)
+  // Check dist package.json bin transformation (flat layout)
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
-  expect(distPkg.bin).toBe("src/cli.js");  // src/cli.js → src/cli.js (npm convention)
+  expect(distPkg.bin).toBe("cli.js");  // src/cli.js → cli.js (flat layout, npm convention)
   
   // Check root package.json bin transformation (no --save)
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
@@ -574,7 +590,7 @@ export const version = "1.0.0";
     name: "@test-scope/my-package",
     version: "1.0.0",
     type: "module",
-    main: "dist/src/index.cjs",
+    main: "dist/index.cjs",
     private: true
   }));
   
@@ -586,17 +602,17 @@ export const version = "1.0.0";
   // Should preserve scoped name
   expect(distPkg.name).toBe("@test-scope/my-package");
   
-  // Should have proper exports structure
+  // Should have proper exports structure (flat layout)
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
-  
-  // Should have proper main/module/types fields
-  expect(distPkg.main).toBe("src/index.cjs");
-  expect(distPkg.module).toBe("src/index.js");
-  expect(distPkg.types).toBe("src/index.d.ts");
+
+  // Should have proper main/module/types fields (flat layout)
+  expect(distPkg.main).toBe("index.cjs");
+  expect(distPkg.module).toBe("index.js");
+  expect(distPkg.types).toBe("index.d.ts");
   
   await removeTempDir(testDir);
 });
@@ -608,46 +624,45 @@ test("comprehensive build verification for multi-entry project", async () => {
   await build(testDir);
   
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
-  
-  // Verify all expected files exist
+
+  // Verify all expected files exist (flat layout: dist root)
   const expectedFiles = [
     "cli.js", "cli.cjs",
-    "utils.js", "utils.cjs", 
+    "utils.js", "utils.cjs",
     "api.js", "api.cjs",
     "index.js", "index.cjs"
   ];
-  
+
   for (const file of expectedFiles) {
-    expect(await fileExists(Path.join(distSrcDir, file))).toBe(true);
+    expect(await fileExists(Path.join(distDir, file))).toBe(true);
   }
-  
+
   // Verify package.json structure
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
-  
+
   // Main entry exports
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
-  
+
   // Individual entry exports
   expect(distPkg.exports["./cli"]).toEqual({
-    types: "./src/cli.d.ts",
-    import: "./src/cli.js",
-    require: "./src/cli.cjs"
+    types: "./cli.d.ts",
+    import: "./cli.js",
+    require: "./cli.cjs"
   });
-  
+
   expect(distPkg.exports["./utils"]).toEqual({
-    types: "./src/utils.d.ts",
-    import: "./src/utils.js",
-    require: "./src/utils.cjs"
+    types: "./utils.d.ts",
+    import: "./utils.js",
+    require: "./utils.cjs"
   });
-  
+
   // Verify smart dependency resolution (no inlining between entry points)
-  const cliContent = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
-  const utilsContent = await FS.readFile(Path.join(distSrcDir, "utils.js"), "utf-8");
+  const cliContent = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
+  const utilsContent = await FS.readFile(Path.join(distDir, "utils.js"), "utf-8");
   
   // CLI should import from utils, not bundle it
   expect(cliContent).toContain('from "./utils.js"');
@@ -688,13 +703,13 @@ test("bin paths follow npm conventions (no ./ prefix)", async () => {
   
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
   
-  // Dist package.json should have bin path without ./ prefix
+  // Dist package.json should have flat bin path without ./ prefix
   expect(distPkg.bin).toEqual({
-    mytool: "src/cli.js"
+    mytool: "cli.js"
   });
-  
-  // Verify the CLI file actually exists
-  expect(await fileExists(Path.join(testDir, "dist", "src", "cli.js"))).toBe(true);
+
+  // Verify the CLI file actually exists at the dist root
+  expect(await fileExists(Path.join(testDir, "dist", "cli.js"))).toBe(true);
   
   // Cleanup
   await removeTempDir(testDir);
@@ -725,17 +740,17 @@ test("bin paths work correctly in --save mode (no double dist/ prefix)", async (
   // Check root package.json
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
   
-  // Should NOT have double dist/ prefix
+  // Should NOT have double dist/ prefix; flattened to the real executable at the dist root
   expect(rootPkg.bin).toEqual({
-    mytool: "./dist/src/cli.js"
+    mytool: "./dist/cli.js"
   });
-  
+
   // Check dist package.json
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
-  
-  // Should have correct relative path without ./ prefix
+
+  // Should have correct flat relative path without ./ prefix
   expect(distPkg.bin).toEqual({
-    mytool: "src/cli.js"
+    mytool: "cli.js"
   });
   
   // Cleanup
@@ -768,15 +783,15 @@ test("bin paths with multiple binaries work correctly", async () => {
   
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
   
-  // All bin paths should be correct
+  // All bin paths should be correct (flat layout)
   expect(distPkg.bin).toEqual({
-    tool1: "src/cli1.js",
-    tool2: "src/cli2.js"
+    tool1: "cli1.js",
+    tool2: "cli2.js"
   });
-  
-  // Verify all CLI files exist
-  expect(await fileExists(Path.join(testDir, "dist", "src", "cli1.js"))).toBe(true);
-  expect(await fileExists(Path.join(testDir, "dist", "src", "cli2.js"))).toBe(true);
+
+  // Verify all CLI files exist at the dist root
+  expect(await fileExists(Path.join(testDir, "dist", "cli1.js"))).toBe(true);
+  expect(await fileExists(Path.join(testDir, "dist", "cli2.js"))).toBe(true);
   
   // Cleanup
   await removeTempDir(testDir);
@@ -804,8 +819,8 @@ test("bin paths handle string format (single binary)", async () => {
   
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
   
-  // String bin should be transformed correctly
-  expect(distPkg.bin).toBe("src/cli.js");
+  // String bin should be transformed correctly (flat layout)
+  expect(distPkg.bin).toBe("cli.js");
   
   // Cleanup
   await removeTempDir(testDir);
@@ -833,11 +848,11 @@ test("bin paths work in --save mode with string format", async () => {
   
   // Check root package.json
   const rootPkg = await readJSON(Path.join(testDir, "package.json"));
-  expect(rootPkg.bin).toBe("./dist/src/cli.js");
-  
+  expect(rootPkg.bin).toBe("./dist/cli.js"); // flattened to the real executable, not the dist/src/ stub
+
   // Check dist package.json
   const distPkg = await readJSON(Path.join(testDir, "dist", "package.json"));
-  expect(distPkg.bin).toBe("src/cli.js");
+  expect(distPkg.bin).toBe("cli.js");
   
   // Cleanup
   await removeTempDir(testDir);

--- a/test/smart-dependency.test.ts
+++ b/test/smart-dependency.test.ts
@@ -14,17 +14,17 @@ test("smart dependency resolution - entry points don't inline other entry points
   // Build
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Check that both entry points were built
-  expect(await fileExists(Path.join(distSrcDir, "cli.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "utils.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "cli.cjs"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "utils.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "cli.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "utils.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "cli.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "utils.cjs"))).toBe(true);
   
   // Read the CLI files to check they import rather than bundle
-  const cliESM = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
-  const cliCJS = await FS.readFile(Path.join(distSrcDir, "cli.cjs"), "utf-8");
+  const cliESM = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
+  const cliCJS = await FS.readFile(Path.join(distDir, "cli.cjs"), "utf-8");
   
   // CLI should import from utils, not bundle it
   expect(cliESM).toContain('import'); // Should have import statement
@@ -37,8 +37,8 @@ test("smart dependency resolution - entry points don't inline other entry points
   expect(cliCJS).not.toContain('function add'); // Should NOT contain inlined utils code
   
   // Utils files should contain the actual implementation
-  const utilsESM = await FS.readFile(Path.join(distSrcDir, "utils.js"), "utf-8");
-  const utilsCJS = await FS.readFile(Path.join(distSrcDir, "utils.cjs"), "utf-8");
+  const utilsESM = await FS.readFile(Path.join(distDir, "utils.js"), "utf-8");
+  const utilsCJS = await FS.readFile(Path.join(distDir, "utils.cjs"), "utf-8");
   
   expect(utilsESM).toContain('function add'); // Utils should have the functions
   expect(utilsESM).toContain('export'); // Should export functions
@@ -47,8 +47,8 @@ test("smart dependency resolution - entry points don't inline other entry points
   // Check that CLI is importing, not bundling
   // Note: With dual runtime shebang, CLI may be slightly larger than utils,
   // but it should still contain the import statement, not the bundled code
-  const cliContent = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
-  const utilsContent = await FS.readFile(Path.join(distSrcDir, "utils.js"), "utf-8");
+  const cliContent = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
+  const utilsContent = await FS.readFile(Path.join(distDir, "utils.js"), "utf-8");
 
   // CLI should import from utils, not bundle it
   expect(cliContent).toContain('from "./utils.js"');
@@ -66,12 +66,12 @@ test("build performance - no duplicate code between entry points", async () => {
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Read all built files
-  const cliJS = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
-  const utilsJS = await FS.readFile(Path.join(distSrcDir, "utils.js"), "utf-8");
-  const apiJS = await FS.readFile(Path.join(distSrcDir, "api.js"), "utf-8");
+  const cliJS = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
+  const utilsJS = await FS.readFile(Path.join(distDir, "utils.js"), "utf-8");
+  const apiJS = await FS.readFile(Path.join(distDir, "api.js"), "utf-8");
   
   // The add function should only be in utils.js, not duplicated
   const addFunctionMatches = [cliJS, utilsJS, apiJS].filter(content => 
@@ -93,10 +93,10 @@ test("significantly reduced bundle sizes with smart dependency resolution", asyn
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
 
   // Check that CLI is importing dependencies, not bundling them
-  const cliContent = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
+  const cliContent = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
 
   // CLI should import from other modules, not bundle them
   expect(cliContent).toContain('from "./utils.js"');
@@ -104,8 +104,8 @@ test("significantly reduced bundle sizes with smart dependency resolution", asyn
   expect(cliContent).not.toContain('function multiply'); // Should NOT bundle multiply function
 
   // Verify no code duplication
-  const utilsContent = await FS.readFile(Path.join(distSrcDir, "utils.js"), "utf-8");
-  const apiContent = await FS.readFile(Path.join(distSrcDir, "api.js"), "utf-8");
+  const utilsContent = await FS.readFile(Path.join(distDir, "utils.js"), "utf-8");
+  const apiContent = await FS.readFile(Path.join(distDir, "api.js"), "utf-8");
   
   // VERSION constant should only appear in utils
   const versionMatches = [cliContent, utilsContent, apiContent].filter(content => 
@@ -123,11 +123,11 @@ test("external entry points plugin handles different extensions correctly", asyn
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Read the built files to check import transformations
-  const cliESM = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
-  const cliCJS = await FS.readFile(Path.join(distSrcDir, "cli.cjs"), "utf-8");
+  const cliESM = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
+  const cliCJS = await FS.readFile(Path.join(distDir, "cli.cjs"), "utf-8");
   
   // ESM should import .js files
   expect(cliESM).toContain('"./utils.js"');
@@ -148,10 +148,10 @@ test("runtime behavior - imports work correctly", async () => {
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Check that the import statements are syntactically correct
-  const cliContent = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
+  const cliContent = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
   
   // Should have valid ES module import
   expect(cliContent).toMatch(/import\s*{\s*add\s*}\s*from\s*['"]\.\/utils\.js['"]/);
@@ -160,7 +160,7 @@ test("runtime behavior - imports work correctly", async () => {
   expect(cliContent).not.toMatch(/require\s*\(\s*['"]\.\/utils/);
   
   // CJS version should have proper require
-  const cliCJSContent = await FS.readFile(Path.join(distSrcDir, "cli.cjs"), "utf-8");
+  const cliCJSContent = await FS.readFile(Path.join(distDir, "cli.cjs"), "utf-8");
   expect(cliCJSContent).toMatch(/require\s*\(\s*['"]\.\/utils\.cjs['"]\s*\)/);
   
   await removeTempDir(testDir);
@@ -173,15 +173,15 @@ test("plugins are properly extracted and organized", async () => {
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Check that plugins directory is NOT created in dist
   // (plugins should be bundled into the main files, not copied)
-  expect(await fileExists(Path.join(distSrcDir, "plugins"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "plugins"))).toBe(false);
   
   // The built files should work without external plugin files
-  expect(await fileExists(Path.join(distSrcDir, "cli.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "utils.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "cli.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "utils.js"))).toBe(true);
   
   await removeTempDir(testDir);
 });
@@ -192,13 +192,13 @@ test("TypeScript plugin only generates declarations for entry points", async () 
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Should NOT have d.ts files for plugins directory
-  expect(await fileExists(Path.join(distSrcDir, "plugins"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "plugins"))).toBe(false);
   
   // Count d.ts files - should match entry points exactly
-  const files = await FS.readdir(distSrcDir);
+  const files = await FS.readdir(distDir);
   const dtsFiles = files.filter(f => f.endsWith('.d.ts'));
   const jsFiles = files.filter(f => f.endsWith('.js'));
   
@@ -224,13 +224,13 @@ test("UMD plugin functionality still works", async () => {
   await copyFixture("with-umd", testDir);
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Should have UMD build
-  expect(await fileExists(Path.join(distSrcDir, "umd.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "umd.js"))).toBe(true);
   
   // Check UMD wrapper structure
-  const umdContent = await FS.readFile(Path.join(distSrcDir, "umd.js"), "utf-8");
+  const umdContent = await FS.readFile(Path.join(distDir, "umd.js"), "utf-8");
   
   // Should contain UMD wrapper pattern
   expect(umdContent).toContain("(function (root, factory)");
@@ -248,15 +248,15 @@ test("shebang preservation in CLI builds", async () => {
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const cliPath = Path.join(testDir, "dist", "src", "cli.js");
+  const cliPath = Path.join(testDir, "dist", "cli.js");
   const cliContent = await FS.readFile(cliPath, "utf-8");
 
   // Should have dual runtime shebang at the top
   expect(cliContent.startsWith("#!/usr/bin/env sh")).toBe(true);
   
   // Should also have triple-slash reference for TypeScript (if d.ts file exists)
-  const distSrcDir = Path.join(testDir, "dist", "src");
-  const dtsExists = await fileExists(Path.join(distSrcDir, "cli.d.ts"));
+  const distDir = Path.join(testDir, "dist");
+  const dtsExists = await fileExists(Path.join(distDir, "cli.d.ts"));
   if (dtsExists) {
     expect(cliContent).toContain("/// <reference types=");
   } else {
@@ -273,10 +273,10 @@ test("no chunking - clean output matching src structure", async () => {
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
-  // Should have clean 1:1 mapping from src to dist/src
-  const files = await FS.readdir(distSrcDir);
+  // Should have clean 1:1 mapping from src to the dist root (flat layout)
+  const files = await FS.readdir(distDir);
   const jsFiles = files.filter(f => f.endsWith('.js'));
   const cjsFiles = files.filter(f => f.endsWith('.cjs'));
   const dtsFiles = files.filter(f => f.endsWith('.d.ts'));
@@ -305,19 +305,17 @@ test("all major features work together", async () => {
   await copyFixture("multi-entry", testDir);
   await build(testDir);
   
-  const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
-  
+  const distDir = Path.join(testDir, "dist");  
   // 1. Smart dependency resolution
-  const cliJS = await FS.readFile(Path.join(distSrcDir, "cli.js"), "utf-8");
+  const cliJS = await FS.readFile(Path.join(distDir, "cli.js"), "utf-8");
   expect(cliJS).toContain('from "./utils.js"'); // Imports, doesn't bundle
   expect(cliJS).not.toContain("export function add"); // No inlined code
   
   // 2. Plugin extraction (no plugin artifacts in output)
-  expect(await fileExists(Path.join(distSrcDir, "plugins"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "plugins"))).toBe(false);
   
   // 3. TypeScript declarations generated cleanly (if available)
-  const files = await FS.readdir(distSrcDir);
+  const files = await FS.readdir(distDir);
   const dtsFiles = files.filter(f => f.endsWith('.d.ts'));
   const jsFiles = files.filter(f => f.endsWith('.js'));
   if (dtsFiles.length > 0) {
@@ -334,7 +332,7 @@ test("all major features work together", async () => {
   expect(chunkFiles).toEqual([]);
   
   // 6. External entry points work for both ESM and CJS
-  const cliCJS = await FS.readFile(Path.join(distSrcDir, "cli.cjs"), "utf-8");
+  const cliCJS = await FS.readFile(Path.join(distDir, "cli.cjs"), "utf-8");
   expect(cliCJS).toContain('"./utils.cjs"'); // CJS requires .cjs
   
   await removeTempDir(testDir);
@@ -352,15 +350,15 @@ test("backwards compatibility - existing features unchanged", async () => {
   
   // Core package.json structure unchanged
   expect(distPkg.name).toBe("simple-lib");
-  expect(distPkg.main).toBe("src/index.cjs");
-  expect(distPkg.module).toBe("src/index.js");
-  expect(distPkg.types).toBe("src/index.d.ts");
+  expect(distPkg.main).toBe("index.cjs");
+  expect(distPkg.module).toBe("index.js");
+  expect(distPkg.types).toBe("index.d.ts");
   
   // Exports structure unchanged
   expect(distPkg.exports["."]).toEqual({
-    types: "./src/index.d.ts",
-    import: "./src/index.js",
-    require: "./src/index.cjs"
+    types: "./index.d.ts",
+    import: "./index.js",
+    require: "./index.cjs"
   });
   
   await removeTempDir(testDir);
@@ -372,15 +370,13 @@ test("plugin integration doesn't break existing functionality", async () => {
   await copyFixture("simple-lib", testDir);
   await build(testDir);
   
-  const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
-  
+  const distDir = Path.join(testDir, "dist");  
   // Basic functionality should still work
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(true);
   
   // Check for TypeScript declaration (may not be generated in test environment)
-  const dtsExists = await fileExists(Path.join(distSrcDir, "index.d.ts"));
+  const dtsExists = await fileExists(Path.join(distDir, "index.d.ts"));
   if (dtsExists) {
     console.log("✓ TypeScript declarations generated");
   } else {
@@ -389,7 +385,7 @@ test("plugin integration doesn't break existing functionality", async () => {
   expect(await fileExists(Path.join(distDir, "package.json"))).toBe(true);
   
   // File contents should be properly built
-  const indexJS = await FS.readFile(Path.join(distSrcDir, "index.js"), "utf-8");
+  const indexJS = await FS.readFile(Path.join(distDir, "index.js"), "utf-8");
   expect(indexJS.length).toBeGreaterThan(0);
   
   // Triple-slash reference only if TypeScript declarations exist
@@ -417,13 +413,13 @@ test("no TypeScript compilation errors", async () => {
   expect(buildError).toBeUndefined();
   
   // All expected files should exist
-  const distSrcDir = Path.join(testDir, "dist", "src");
-  expect(await fileExists(Path.join(distSrcDir, "cli.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "utils.js"))).toBe(true);
+  const distDir = Path.join(testDir, "dist");
+  expect(await fileExists(Path.join(distDir, "cli.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "utils.js"))).toBe(true);
   
   // Check for TypeScript declarations (may not be generated in test environment)
-  const cliDtsExists = await fileExists(Path.join(distSrcDir, "cli.d.ts"));
-  const utilsDtsExists = await fileExists(Path.join(distSrcDir, "utils.d.ts"));
+  const cliDtsExists = await fileExists(Path.join(distDir, "cli.d.ts"));
+  const utilsDtsExists = await fileExists(Path.join(distDir, "utils.d.ts"));
   if (cliDtsExists && utilsDtsExists) {
     console.log("✓ TypeScript declarations generated successfully");
   } else {
@@ -452,7 +448,7 @@ export function b() { return 'b'; }
   await FS.writeFile(Path.join(testDir, "package.json"), JSON.stringify({
     name: "circular-test",
     version: "1.0.0",
-    main: "dist/src/a.cjs",
+    main: "dist/a.cjs",
     type: "module"
   }));
   
@@ -467,9 +463,9 @@ export function b() { return 'b'; }
   expect(buildError).toBeUndefined();
   
   // a.js should import from b.js, not bundle it
-  const distSrcDir = Path.join(testDir, "dist", "src");
-  const aContent = await FS.readFile(Path.join(distSrcDir, "a.js"), "utf-8");
-  const bContent = await FS.readFile(Path.join(distSrcDir, "b.js"), "utf-8");
+  const distDir = Path.join(testDir, "dist");
+  const aContent = await FS.readFile(Path.join(distDir, "a.js"), "utf-8");
+  const bContent = await FS.readFile(Path.join(distDir, "b.js"), "utf-8");
   
   expect(aContent).toContain('from "./b.js"');
   expect(bContent).toContain('function b'); // b.js should contain the b function
@@ -490,17 +486,17 @@ test("shared modules are deduplicated across entry points", async () => {
   // Build
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Check that all entry files exist
-  expect(await fileExists(Path.join(distSrcDir, "entry1.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "entry2.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "shared.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "entry1.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "entry2.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "shared.js"))).toBe(true);
   
   // Read the built files
-  const entry1JS = await FS.readFile(Path.join(distSrcDir, "entry1.js"), "utf-8");
-  const entry2JS = await FS.readFile(Path.join(distSrcDir, "entry2.js"), "utf-8");
-  const sharedJS = await FS.readFile(Path.join(distSrcDir, "shared.js"), "utf-8");
+  const entry1JS = await FS.readFile(Path.join(distDir, "entry1.js"), "utf-8");
+  const entry2JS = await FS.readFile(Path.join(distDir, "entry2.js"), "utf-8");
+  const sharedJS = await FS.readFile(Path.join(distDir, "shared.js"), "utf-8");
   
   // Verify that shared code is in the shared.js file
   expect(sharedJS).toContain("sharedUtility");
@@ -518,9 +514,9 @@ test("shared modules are deduplicated across entry points", async () => {
   expect(entry2JS).not.toContain("class SharedClass");
   
   // Check file sizes - entry files should be smaller than shared file
-  const entry1Stats = await FS.stat(Path.join(distSrcDir, "entry1.js"));
-  const entry2Stats = await FS.stat(Path.join(distSrcDir, "entry2.js"));
-  const sharedStats = await FS.stat(Path.join(distSrcDir, "shared.js"));
+  const entry1Stats = await FS.stat(Path.join(distDir, "entry1.js"));
+  const entry2Stats = await FS.stat(Path.join(distDir, "entry2.js"));
+  const sharedStats = await FS.stat(Path.join(distDir, "shared.js"));
   
   // Shared file should be the largest since it contains the bulk of the code
   expect(sharedStats.size).toBeGreaterThan(entry1Stats.size);
@@ -539,19 +535,19 @@ test("shared modules work with both ESM and CJS builds", async () => {
   // Build
   await build(testDir);
   
-  const distSrcDir = Path.join(testDir, "dist", "src");
+  const distDir = Path.join(testDir, "dist");
   
   // Check that both ESM and CJS files exist
-  expect(await fileExists(Path.join(distSrcDir, "entry1.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "entry1.cjs"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "shared.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "shared.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "entry1.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "entry1.cjs"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "shared.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "shared.cjs"))).toBe(true);
   
   // Read both formats
-  const entry1ESM = await FS.readFile(Path.join(distSrcDir, "entry1.js"), "utf-8");
-  const entry1CJS = await FS.readFile(Path.join(distSrcDir, "entry1.cjs"), "utf-8");
-  const sharedESM = await FS.readFile(Path.join(distSrcDir, "shared.js"), "utf-8");
-  const sharedCJS = await FS.readFile(Path.join(distSrcDir, "shared.cjs"), "utf-8");
+  const entry1ESM = await FS.readFile(Path.join(distDir, "entry1.js"), "utf-8");
+  const entry1CJS = await FS.readFile(Path.join(distDir, "entry1.cjs"), "utf-8");
+  const sharedESM = await FS.readFile(Path.join(distDir, "shared.js"), "utf-8");
+  const sharedCJS = await FS.readFile(Path.join(distDir, "shared.cjs"), "utf-8");
   
   // Verify ESM imports
   expect(entry1ESM).toContain('from "./shared.js"');
@@ -578,12 +574,12 @@ test("peer dependencies are externalized in both ESM and CJS", async () => {
 
   await build(testDir);
 
-  const distSrcDir = Path.join(testDir, "dist", "src");
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(true);
+  const distDir = Path.join(testDir, "dist");
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(true);
 
-  const esm = await FS.readFile(Path.join(distSrcDir, "index.js"), "utf-8");
-  const cjs = await FS.readFile(Path.join(distSrcDir, "index.cjs"), "utf-8");
+  const esm = await FS.readFile(Path.join(distDir, "index.js"), "utf-8");
+  const cjs = await FS.readFile(Path.join(distDir, "index.cjs"), "utf-8");
 
   // ESM keeps the bare import
   expect(esm).toContain('from "@fictional-scope/peer-lib"');

--- a/test/tla-support.test.ts
+++ b/test/tla-support.test.ts
@@ -39,20 +39,19 @@ export const data = config;
   await build(testDir, false);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
-  // ESM file should exist
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
+  // ESM file should exist at dist root
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
 
   // CJS file should NOT exist (disabled due to TLA)
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(false);
 
   // Check package.json was generated without CJS/require fields
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
 
   // Should have ESM export only
   expect(distPkg.exports["."]).toBeDefined();
-  expect(distPkg.exports["."].import).toBe("./src/index.js");
+  expect(distPkg.exports["."].import).toBe("./index.js");
   expect(distPkg.exports["."].require).toBeUndefined(); // No require field
 
   // Should not have main field
@@ -99,17 +98,16 @@ test("TLA in some files disables all CJS generation", async () => {
   await build(testDir, false);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
-  // ESM files should exist
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "utils.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "async-config.js"))).toBe(true);
+  // ESM files should exist at dist root
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "utils.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "async-config.js"))).toBe(true);
 
   // NO CJS files should exist (TLA in one file disables all CJS)
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(false);
-  expect(await fileExists(Path.join(distSrcDir, "utils.cjs"))).toBe(false);
-  expect(await fileExists(Path.join(distSrcDir, "async-config.cjs"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "utils.cjs"))).toBe(false);
+  expect(await fileExists(Path.join(distDir, "async-config.cjs"))).toBe(false);
 
   // Check exports don't have require fields
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
@@ -151,8 +149,8 @@ test("TLA with --save doesn't add main field", async () => {
   expect(rootPkg.main).toBeUndefined();
 
   // Should have module and types for ESM
-  expect(rootPkg.module).toBe("./dist/src/index.js");
-  expect(rootPkg.types).toBe("./dist/src/index.d.ts");
+  expect(rootPkg.module).toBe("./dist/index.js");
+  expect(rootPkg.types).toBe("./dist/index.d.ts");
 
   await removeTempDir(testDir);
 });
@@ -183,17 +181,16 @@ test("Non-TLA project still generates CJS normally", async () => {
   await build(testDir, false);
 
   const distDir = Path.join(testDir, "dist");
-  const distSrcDir = Path.join(distDir, "src");
 
-  // Both ESM and CJS should exist
-  expect(await fileExists(Path.join(distSrcDir, "index.js"))).toBe(true);
-  expect(await fileExists(Path.join(distSrcDir, "index.cjs"))).toBe(true);
+  // Both ESM and CJS should exist at dist root
+  expect(await fileExists(Path.join(distDir, "index.js"))).toBe(true);
+  expect(await fileExists(Path.join(distDir, "index.cjs"))).toBe(true);
 
   // Check package.json has both import and require
   const distPkg = await readJSON(Path.join(distDir, "package.json"));
-  expect(distPkg.exports["."].import).toBe("./src/index.js");
-  expect(distPkg.exports["."].require).toBe("./src/index.cjs");
-  expect(distPkg.main).toBe("src/index.cjs");
+  expect(distPkg.exports["."].import).toBe("./index.js");
+  expect(distPkg.exports["."].require).toBe("./index.cjs");
+  expect(distPkg.main).toBe("index.cjs");
 
   await removeTempDir(testDir);
 });


### PR DESCRIPTION
Closes #9.

## What this does

Modules publish at the tarball **root** (`<pkg>/index.js`) instead of nested under `src/`. jsDelivr/unpkg serve literal paths and never consult the exports map, so the old layout 404'd every copy-pasted CDN file URL. This is the default behavior — no config flag — and a **clean break**: no compatibility layer ships.

| consumer | before | after |
|---|---|---|
| `cdn.jsdelivr.net/npm/<pkg>/index.js` | 404 | **200** |
| `cdn.jsdelivr.net/npm/<pkg>/src/index.js` | 200 | **404 after republish** (accepted break) |
| bare specifier / exports map | works | works (keys never contained `src/`) |
| `npm link` root/dist symmetry | works | works (`dist/` prefix strip unchanged) |

The accepted break is small by construction: the `src/` layout only ever existed for packages published with libuild 0.1.x (~9 months). The crank-ecosystem URLs that motivated #9 are already flat — this *restores* them.

## Layout

```
dist/
  index.js  index.cjs  index.d.ts     # modules at the root
  bin/cli.js                          # executables stay in bin/
  _chunks/                            # code-splitting chunks
  impl/…                              # internal modules relocate with the tree
  package.json  README.md  …
```

Design notes from the issue discussion:
- **Proposal A** (flat build via explicit `{in, out}` entry points), not B — keeping `bin/` as a subdir at build time is what per-entry output mapping gives natively.
- **No collision guard needed**: with `bin/` a subdir and outputs carrying `.js/.cjs/.d.ts` extensions, no reachable collision with copied metadata files exists. (The `src/bin/` entry flavor in the old code is dead — nothing produces `source: 'src'`.)
- An earlier revision of this branch shipped re-export stubs under `dist/src/` for old URLs; dropped in the second commit per discussion — band-aid off.

## Bugs found & fixed along the way

1. **UMD plugin corrupted sibling entries** (pre-existing on main): it wrapped *every* `.js` in its outdir, so any package with `src/umd.ts` plus other entries shipped UMD-mangled ESM files. Now wraps only its own output; regression test included.
2. **`--save` bin kept stale nested paths** (caught by test-update agent): `bin: "src/cli.js"` saved as `./dist/src/cli.js`; now flattened to the real executable.
3. **`--save` idempotency** (caught by agents): the ambient `.d.ts` export whitelist and the multi-entry discovery heuristic both assumed `/src/`-shaped saved values; both now accept flat forms.

## Verification

- 137 tests, 133 pass — the 4 failures are the pre-existing npm-flag-filtering failures, identical on `main`.
- New `test/flat-output.test.ts`: flat layout + no `src/` in output, root-module runtime resolution (CDN-literal simulation), #1-style guard (internal-module `.d.ts` + `declare module` relocate together, relative imports intact), UMD non-corruption, `npm pack` tarball shape (asserts nothing ships under `src/`), `--save` bin regression.
- E2E outside the suite: packed a fixture tarball, consumed via `tsc` (`nodenext`) through the exports map — typechecks; runtime imports work.
- Dogfooded: libuild builds itself flat (`dist/src` gone), CLI executes, `--save` round-trips.

## Also in this release (maintenance batch)

Per "never let a breaking change go to waste", commit 26b6723 folds in:
- **esbuild `^0.19` → `^0.28.1`** (nine esbuild-breaking minors; zero API fallout), commander 15, patch bumps
- **.tsx entry points** (#6): discovered and built; tsconfig jsx settings honored for declarations
- **#7 fixed**: `--save` no longer drops `import`/`require` conditions from a types-only `.` export
- **publish flag whitelist restored**: the security validation from 47a93bb was silently dropped in the commander rewrite — the 4 chronically failing security tests were right all along. **Suite is now fully green: 139 pass, 0 fail.**
- dead-code removal (unreachable src/bin flavor, unused params, deprecated substr)

## Breaking-change notes (0.2.0)

- Literal `<pkg>/src/*` URLs into previously published packages 404 once those packages republish. Node/bundler consumers unaffected.
- Root `--save` paths change shape (`./dist/index.js`); old saved paths migrate automatically on the next `--save`.
- The dist `files` field is dropped when it only contained layout dirs (npm packs the whole dist dir); author extras keep the field with module patterns appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)