### PR TITLE
Per-file import.meta paths in test bundles; honest zero-test counts; TS6 peer (0.2.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.20] - 2026-08-17
+
+### Fixed
+- **`import.meta.url` / `.dirname` / `.filename` point at the source test file, not the bundle** (reported by the fold migration). Bundling collapsed every module's location to `.libuild-test/bundle-*.js`, silently breaking the fixtures-next-to-the-test pattern (`new URL("./fixtures/x.json", import.meta.url)`) with failures that read as bugs in the code under test. On node/bun bundles, esbuild's `define` now maps the three path-shaped members to per-file bindings injected (one line, no line-number shift) into each file that mentions `import.meta`. Browser bundles are unchanged - a page has no source filesystem. (`import.meta` used bare, or other properties, still see the bundle.)
+- **A file that registers no tests counts as `0 passed`, not `1`** (fold's `tests/helpers.js`). node fabricates one passing test named with the file's path when a file registers nothing, and includes it in `# pass`; the synthetic entry is now recognized and excluded, so shared helpers swept up by the test glob report honestly.
+
+### Changed
+- **`typescript` peer range widened to `^5.0.0 || ^6.0.0`** - installs alongside TypeScript 6 no longer ERESOLVE.
+
 ## [0.2.19] - 2026-08-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/libuild",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Zero-config library builds",
   "main": "./dist/libuild.cjs",
   "bin": {
@@ -21,7 +21,7 @@
     "pretty-format": "^30.4.1"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0",
+    "typescript": "^5.0.0 || ^6.0.0",
     "playwright": "^1.40.0"
   },
   "peerDependenciesMeta": {

--- a/src/_test-runner.ts
+++ b/src/_test-runner.ts
@@ -430,6 +430,64 @@ function resolveLibuildDir(cwd: string): string | null {
   }
 }
 
+// Loader by extension, for plugins that read source files themselves.
+function loaderFor(path: string): ESBuild.Loader {
+  const ext = Path.extname(path).toLowerCase();
+  return ext === ".ts" || ext === ".mts" ? "ts"
+    : ext === ".tsx" ? "tsx"
+    : ext === ".jsx" ? "jsx"
+    : "js";
+}
+
+/**
+ * Keep `import.meta.url` / `.dirname` / `.filename` pointing at each SOURCE
+ * file instead of the bundle. Bundling collapses every module's location to
+ * `.libuild-test/bundle-*.js`, which silently breaks the
+ * fixtures-next-to-the-test pattern (`new URL("./fixtures/x.json",
+ * import.meta.url)`, `import.meta.dirname`) with failures that read as bugs
+ * in the code under test - fold lost 3 of 20 files to this and the symptoms
+ * looked like formatter defects.
+ *
+ * esbuild has no per-file define, so the standard sidestep: `define` maps the
+ * three member expressions to bare identifiers, and this plugin prepends a
+ * one-line `var` declaration binding them to the source file's real location
+ * in every in-bundle file that mentions `import.meta`. One line, appended
+ * BEFORE the original first line without a newline, so line numbers in stack
+ * traces don't shift. esbuild renames the vars per module, so each file keeps
+ * its own values. Only `import.meta` files pay; everything else loads
+ * natively. (`import.meta` used bare, or other properties, still see the
+ * bundle - only the three path-shaped members are redirected.)
+ */
+const IMPORT_META_DEFINE = {
+  "import.meta.url": "__libuild_import_meta_url",
+  "import.meta.dirname": "__libuild_import_meta_dirname",
+  "import.meta.filename": "__libuild_import_meta_filename",
+};
+
+function makeImportMetaPlugin(): ESBuild.Plugin {
+  return {
+    name: "libuild-import-meta",
+    setup(build) {
+      build.onLoad({ filter: /\.(ts|tsx|mts|js|jsx|mjs)$/ }, async (args) => {
+        // node_modules is external on node/bun, so this only ever sees the
+        // consumer's own files plus the generated entry.
+        const contents = await FS.readFile(args.path, "utf-8");
+        if (!contents.includes("import.meta")) return undefined; // load natively
+        const url = new URL(`file://${args.path.replace(/\\/g, "/")}`).href;
+        const prefix =
+          `var __libuild_import_meta_url = ${JSON.stringify(url)}, ` +
+          `__libuild_import_meta_dirname = ${JSON.stringify(Path.dirname(args.path))}, ` +
+          `__libuild_import_meta_filename = ${JSON.stringify(args.path)}; `;
+        return {
+          contents: prefix + contents,
+          loader: loaderFor(args.path),
+          resolveDir: Path.dirname(args.path),
+        };
+      });
+    },
+  };
+}
+
 /**
  * Bundle tests for a specific platform.
  * Exported for tests that assert externalization behavior.
@@ -495,12 +553,16 @@ const require = createRequire(import.meta.url);
     // the browser branch never does.
     ...(isBrowser
       ? { plugins: [makeBrowserStubPlugin(resolveLibuildDir(cwd))] }
-      : { packages: "external" as const }),
+      : { packages: "external" as const, plugins: [makeImportMetaPlugin()] }),
     // Inject require shim for node/bun to handle CJS deps like expect/chalk
     ...(isBrowser ? {} : { banner: { js: requireShim } }),
-    // Define for dead code elimination
+    // Define for dead code elimination; on node/bun also redirect the three
+    // path-shaped import.meta members to per-file bindings (see
+    // makeImportMetaPlugin). Browser bundles keep the bundle-relative
+    // meaning - there is no source filesystem in a page.
     define: {
       "process.env.NODE_ENV": '"test"',
+      ...(isBrowser ? {} : IMPORT_META_DEFINE),
     },
     logLevel: "warning",
   };
@@ -525,7 +587,7 @@ const TAP_DIRECTIVE = /(?<!\\)#\s*(TODO|SKIP)\b/i;
  * the counts; fall back to a directive-aware per-test tally if they're absent.
  * Exported for unit testing.
  */
-export function parseTapOutput(output: string): { passed: number; failed: number; errors: Array<{ name: string; error: string }>; skipped: number; todo: number; completed: boolean } {
+export function parseTapOutput(output: string, syntheticName?: string): { passed: number; failed: number; errors: Array<{ name: string; error: string }>; skipped: number; todo: number; completed: boolean } {
   output = stripAnsi(output); // forced color must not corrupt the TAP tokens
   const errors: Array<{ name: string; error: string }> = [];
 
@@ -549,9 +611,22 @@ export function parseTapOutput(output: string): { passed: number; failed: number
   // as it used to - `failureType` and `error` come after it in the block.
   let current: { name: string; notOk: boolean; type?: string; failureType?: string; error?: string } | null = null;
 
+  // When a file registers NO tests, node fabricates one passing test entry
+  // named with the file's path and reports "# pass 1" - so a shared helper
+  // picked up by the test glob shows as "1 passed" (fold's tests/helpers.js).
+  // Files with real tests never get the synthetic entry (or every file would
+  // inflate its count by one). The caller passes the bundle's basename;
+  // a passing test whose name ends with it is the fabrication, not a test.
+  let syntheticSeen = 0;
+
   const finalize = () => {
     if (!current) return;
     if (current.type === "test") {
+      if (syntheticName && !current.notOk && current.name.endsWith(syntheticName)) {
+        syntheticSeen++;
+        current = null;
+        return;
+      }
       const directive = current.name.match(TAP_DIRECTIVE);
       const kind = directive ? directive[1].toUpperCase() : null;
       if (kind === "SKIP") {
@@ -613,7 +688,9 @@ export function parseTapOutput(output: string): { passed: number; failed: number
     || (tallyPassed + tallyFailed + tallySkipped + tallyTodo + suiteFailed) > 0;
 
   return {
-    passed: summary("pass") ?? tallyPassed,
+    // The synthetic file-entry (if seen) is inside node's own "# pass" count
+    // too, so it is subtracted from the summary path as well as the tally.
+    passed: Math.max(0, (summary("pass") ?? tallyPassed + syntheticSeen) - syntheticSeen),
     failed: (summary("fail") ?? tallyFailed) + suiteFailed,
     skipped: summary("skipped") ?? tallySkipped,
     todo: summary("todo") ?? tallyTodo,
@@ -746,7 +823,7 @@ async function runNodeTests(bundlePath: string, timeout: number): Promise<ShardR
     };
   }
 
-  const { passed, failed, errors, skipped, todo, completed } = parseTapOutput(stdout);
+  const { passed, failed, errors, skipped, todo, completed } = parseTapOutput(stdout, Path.basename(bundlePath));
   const reason = shardFailure({
     completed, code, signal, timedOut, failed, timeout,
     finished: passed + failed + skipped + todo,

--- a/test/test-runner.test.ts
+++ b/test/test-runner.test.ts
@@ -752,6 +752,69 @@ test("registration counting covers only/skip/todo/each (denominator accuracy)", 
   }
 });
 
+test("import.meta.url/dirname/filename point at the source file, not the bundle", async () => {
+  const testDir = await createTempDir("import-meta");
+  const projDir = Path.join(testDir, "proj");
+  await FS.mkdir(Path.join(projDir, "tests", "fixtures"), {recursive: true});
+  await FS.writeFile(Path.join(projDir, "package.json"),
+    JSON.stringify({name: "p", version: "1.0.0", type: "module"}));
+  await FS.writeFile(Path.join(projDir, "tests", "fixtures", "data.json"), '{"answer": 42}\n');
+  // The mainstream pattern bundling used to break silently: fixtures next to
+  // the test, addressed via import.meta. Failures surfaced deep inside the
+  // code under test ("0 files parsed") and read as its bugs, not libuild's.
+  await FS.writeFile(Path.join(projDir, "tests", "paths.test.js"),
+    'import {test} from "node:test";\n' +
+    'import assert from "node:assert/strict";\n' +
+    'import {readFileSync} from "node:fs";\n' +
+    'test("dirname is the source dir", () => {\n' +
+    '  assert.ok(!import.meta.dirname.includes(".libuild-test"), import.meta.dirname);\n' +
+    '  assert.ok(import.meta.filename.endsWith("paths.test.js"), import.meta.filename);\n' +
+    '});\n' +
+    'test("fixture loads relative to the test file", () => {\n' +
+    '  const data = JSON.parse(readFileSync(new URL("./fixtures/data.json", import.meta.url), "utf-8"));\n' +
+    '  assert.equal(data.answer, 42);\n' +
+    '});\n');
+
+  expect(await runTests({cwd: projDir, platforms: ["node"], timeout: 30000})).toBe(true);
+
+  await removeTempDir(testDir);
+});
+
+test("a helper file that registers no tests counts as 0 passed, not 1", () => {
+  // node fabricates one passing test named with the file path when a file
+  // registers nothing, and includes it in "# pass" - so shared helpers under
+  // the test glob showed as "1 passed". The synthetic entry is recognized by
+  // the bundle basename and excluded from both the tally and the summary.
+  const tap = `TAP version 13
+# Subtest: /tmp/x/.libuild-test/bundle-node-3.js
+ok 1 - /tmp/x/.libuild-test/bundle-node-3.js
+  ---
+  duration_ms: 20
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 21
+`;
+  const r = parseTapOutput(tap, "bundle-node-3.js");
+  expect(r.passed).toBe(0);
+  expect(r.failed).toBe(0);
+  expect(r.completed).toBe(true); // an empty file is still a completed run
+
+  // Without the synthetic name (bun path, or older transcripts), behavior is
+  // unchanged; and a REAL test file's counts are untouched because node emits
+  // no synthetic entry when actual tests exist.
+  expect(parseTapOutput(tap).passed).toBe(1);
+  expect(parseTapOutput(NODE_TAP, "bundle-node-0.js").passed).toBe(1);
+  expect(parseTapOutput(NODE_TAP, "bundle-node-0.js").failed).toBe(2);
+});
+
 test("a describe-callback throw fails the node run end-to-end (#23)", async () => {
   const testDir = await createTempDir("suite-throw-e2e");
   const projDir = Path.join(testDir, "proj");


### PR DESCRIPTION
Fixes all three findings from the fold session's report (eslint-plugin-fold migration).

## 1. `import.meta.url`/`.dirname`/`.filename` per source file

Bundling collapsed every module's location to `.libuild-test/` — silent, and misattributing (fold lost 3 of 20 files to failures that looked like formatter bugs). esbuild has no per-file define, so: `define` maps the three path-shaped members to bare identifiers, and a plugin prepends a **one-line** `var` binding (no newline → no line-number shift) into each in-bundle file mentioning `import.meta`. esbuild scope-renames per module, so each file keeps its own values, and tree-shakes unused ones. node/bun only — browser pages have no source filesystem. The require-shim banner is emitted verbatim, so its own `import.meta.url` is unaffected.

Chose the rewrite over not bundling on node: bundling is still what provides TS transpilation, `./x.js`→`.ts` specifier mapping, setup-file injection, and the snapshot globals — dropping it on node would fork the execution model per platform.

## 2. Zero-test files report 0 passed

node fabricates a passing test named with the file's path when a file registers nothing (files with real tests never get it — counts were never inflated, verified). Recognized by bundle basename, excluded from tally and summary. `helpers.js: 0 passed, 0 failed`.

## 3. `typescript` peer: `^5.0.0 || ^6.0.0`

## Verification

- Reporter's exact repro passes on node and bun; fixture-relative `new URL(...)` loading e2e-tested
- Full suite: 199 pass / 0 fail
- The fold session is running its 158-test suite (fixtures, 10-repo corpus, Prettier differential) against this branch as a canary; merge waits on that report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAc3iDuBb3zN41HrepErUw