### PR TITLE
fix: first CI run of the suite - build dist, portable ps, CI-mode .only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
 
       - run: bun install
 
+      # The suite's consumer-project fixtures symlink node_modules/@b9g/libuild
+      # at ./dist, which is gitignored - build it or those tests dangle.
+      - run: bun run src/cli.ts
+
       - run: bun test
 
       # A mistyped tag would otherwise publish whatever the manifest says, and

--- a/test/esbuild-recovery.test.ts
+++ b/test/esbuild-recovery.test.ts
@@ -143,13 +143,22 @@ describe("esbuild service restart (integration, real service)", () => {
       // Healthy build first - this is what spawns the service child.
       await build(opts);
 
-      // Kill only OUR OWN service child (`pgrep -P <this pid>`), never a
-      // machine-wide `pgrep -f esbuild`: under per-file isolation, sibling
-      // shard processes have their own services, and killing theirs would
-      // make this test the very cascade-failure it exists to prevent.
-      const pids = execSync(`pgrep -P ${process.pid} -f esbuild || true`, {encoding: "utf-8"})
-        .trim().split("\n").filter(Boolean);
-      expect(pids.length).toBeGreaterThan(0);
+      // Kill only OUR OWN service child, never a machine-wide match: under
+      // per-file isolation, sibling shard processes have their own services,
+      // and killing theirs would make this test the very cascade-failure it
+      // exists to prevent. `ps` rather than `pgrep -P`: portable across
+      // macOS/Linux (pgrep -P -f missed the child on ubuntu CI), and the raw
+      // table makes a zero-match failure diagnosable instead of a bare count.
+      const psOut = execSync("ps -ax -o pid=,ppid=,command=", {encoding: "utf-8"});
+      const pids = psOut.split("\n")
+        .map((line) => line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/))
+        .filter((m): m is RegExpMatchArray =>
+          m != null && parseInt(m[2], 10) === process.pid && m[3].includes("esbuild"))
+        .map((m) => m[1]);
+      if (pids.length === 0) {
+        throw new Error(`no esbuild service child of pid ${process.pid} found; children:\n` +
+          psOut.split("\n").filter((l) => l.trim().split(/\s+/)[1] === String(process.pid)).join("\n"));
+      }
       for (const pid of pids) process.kill(parseInt(pid, 10), "SIGKILL");
       // Give esbuild's JS side a beat to observe the closed streams.
       await new Promise((r) => setTimeout(r, 300));

--- a/test/flat-output.test.ts
+++ b/test/flat-output.test.ts
@@ -139,8 +139,17 @@ test("flat layout: npm pack ships root modules, no src/ paths", async () => {
 
   const proc = Bun.spawn(["npm", "pack", "--dry-run", "--json"], {cwd: distDir, stdout: "pipe", stderr: "pipe"});
   const out = await new Response(proc.stdout).text();
+  const errOut = await new Response(proc.stderr).text();
   await proc.exited;
-  const packed = JSON.parse(out)[0].files.map((f: any) => f.path);
+  // Parse defensively and fail LOUD: an environment problem (auth-poisoned
+  // .npmrc, npm output-format change) must show npm's actual output, not a
+  // bare "undefined is not an object" (first seen on the first-ever CI run).
+  let packed: string[];
+  try {
+    packed = JSON.parse(out)[0].files.map((f: any) => f.path);
+  } catch (error: any) {
+    throw new Error(`npm pack --json output unparseable (exit ${proc.exitCode}): ${error?.message}\nstdout:\n${out}\nstderr:\n${errOut}`);
+  }
 
   // Canonical modules at the tarball root (clean CDN URLs: <pkg>/index.js)
   expect(packed).toContain("index.js");
@@ -265,8 +274,17 @@ test("relocated subdirectory declarations ship in the tarball (#11)", async () =
 
   const proc = Bun.spawn(["npm", "pack", "--dry-run", "--json"], {cwd: distDir, stdout: "pipe", stderr: "pipe"});
   const out = await new Response(proc.stdout).text();
+  const errOut = await new Response(proc.stderr).text();
   await proc.exited;
-  const packed = JSON.parse(out)[0].files.map((f: any) => f.path);
+  // Parse defensively and fail LOUD: an environment problem (auth-poisoned
+  // .npmrc, npm output-format change) must show npm's actual output, not a
+  // bare "undefined is not an object" (first seen on the first-ever CI run).
+  let packed: string[];
+  try {
+    packed = JSON.parse(out)[0].files.map((f: any) => f.path);
+  } catch (error: any) {
+    throw new Error(`npm pack --json output unparseable (exit ${proc.exitCode}): ${error?.message}\nstdout:\n${out}\nstderr:\n${errOut}`);
+  }
 
   // The relocated declaration referenced by index.d.ts actually ships
   expect(packed).toContain("internal/helper.d.ts");

--- a/test/test-runner.test.ts
+++ b/test/test-runner.test.ts
@@ -1155,12 +1155,24 @@ test("wrapTestApi works against the REAL bun:test object, not just a mock (#14)"
   const bunTest: any = await import("bun:test");
   const api = wrapTestApi({describe: bunTest.describe, test: bunTest.test, it: bunTest.it});
 
-  // Reading a branded getter (the primary bug) would throw right here.
+  // Reading a branded getter (the primary bug) would throw right here. One
+  // deliberate exception: newer bun makes reading `.only` THROW under CI
+  // ("disabled in CI environments") - the proxy must preserve that exactly as
+  // native, so under CI the assertion is "throws bun's message", not "is a
+  // function".
+  const expectSubMethod = (obj: any, key: string) => {
+    try {
+      expect(typeof obj[key]).toBe("function");
+    } catch (error: any) {
+      if (key === "only" && /disabled in CI/i.test(error?.message ?? "")) return;
+      throw error;
+    }
+  };
   for (const key of ["todo", "skip", "only", "skipIf", "todoIf", "each"]) {
-    expect(typeof (api.test as any)[key]).toBe("function");
+    expectSubMethod(api.test, key);
   }
   for (const key of ["skip", "only", "each"]) {
-    expect(typeof (api.describe as any)[key]).toBe("function");
+    expectSubMethod(api.describe, key);
   }
   // `.each` is branded at CALL time too; building a registrar from an EMPTY table
   // exercises that path without registering any tests.


### PR DESCRIPTION
The release workflow's first execution ran the suite in CI for the
first time and surfaced four environment assumptions:

- The workflow never built dist/, so consumer-project fixtures that
  symlink node_modules/@b9g/libuild at ./dist dangled ("Could not
  resolve @b9g/libuild/test"). The workflow now builds before testing.
- Newer bun makes READING test.only throw under CI ("disabled in CI
  environments") - by design, and the snapshot proxy correctly
  preserves it. The wrapTestApi test now asserts that preservation
  under CI instead of insisting .only is a readable function.
- pgrep -P -f missed the esbuild service child on ubuntu. Child
  discovery now parses ps -ax (portable), still scoped to THIS
  process's children only, and dumps the process table on zero
  matches instead of failing with a bare count.
- The npm pack --json tests failed with "undefined is not an object"
  hiding npm's actual output. They now parse defensively and fail
  loudly with exit code, stdout, and stderr - so if CI's npm
  environment breaks the format again, the log says how.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
